### PR TITLE
persistStore: typo in catch block

### DIFF
--- a/src/persistStore.js
+++ b/src/persistStore.js
@@ -184,7 +184,7 @@ var defaultStorage = {
       cb(null, keys)
     }
     catch(e){
-      cb(err)
+      cb(e)
     }
   }
 }


### PR DESCRIPTION
Stumbled upon this while casually browsing the source - I guess this is an untested code path.