### PR TITLE
Remove localStorage var that clobbers the global

### DIFF
--- a/src/defaults/asyncLocalStorage.js
+++ b/src/defaults/asyncLocalStorage.js
@@ -1,5 +1,4 @@
 var nextTick = process && process.nextTick ? process.nextTick : setImmediate
-var localStorage = localStorage || null
 
 export default {
   getItem: function (key, cb) {


### PR DESCRIPTION
Declaring a var localStorage at the top level clobbers the global localStorage defined by the browser with `undefined`.

It wasn't clear what that line was trying to accomplish and it works without it.