### PR TITLE
Fix for Immutable.js warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test:watch": "npm test -- --watch",
     "clean": "rimraf lib dist",
     "build": "babel src --out-dir lib",
-    "build:watch": "watch 'npm run build' ./src",
+    "build:watch": "npm run build ./src -- -watch",
     "prepublish": "npm run clean && npm run build"
   },
   "repository": {

--- a/src/autoRehydrate.js
+++ b/src/autoRehydrate.js
@@ -21,6 +21,15 @@ module.exports = function autoRehydrate (config = {}) {
     if (config.log) console.log('redux-persist/autoRehydrate action buffer released', queue)
   }
 
+  function checkIsObject (data, reducedState, key) {
+    if ((data.size || data.hasOwnProperty('size')) || (reducedState[key].size || reducedState[key].hasOwnProperty('size'))) {
+      return true
+    } else if (isPlainObject(data) || isPlainObject(reducedState[key])) {
+      return true
+    }
+    return false
+  }
+
   function createRehydrationReducer (reducer) {
     return (state, action) => {
       if (action.type === REHYDRATE) {
@@ -35,7 +44,8 @@ module.exports = function autoRehydrate (config = {}) {
         }
 
         let autoReducedState = {...reducedState}
-        if (!isPlainObject(data) || !isPlainObject(reducedState[key])) {
+        let isObject = checkIsObject(data, reducedState, key)
+        if (!isObject) {
           // assign value
           autoReducedState[key] = data
         } else {


### PR DESCRIPTION
When checking if data is an object using lodash methods, part of the process is to determine is an object is actually an array. lodash checks for the length property and this is not supported in Immutable.js - this fix prevents an warning being logged in modern browsers and a breaking error in IE9 or below. 