### PR TITLE
Change the way of checking for localStorage access

### DIFF
--- a/src/defaults/asyncLocalStorage.js
+++ b/src/defaults/asyncLocalStorage.js
@@ -7,7 +7,16 @@ const noLS = process && process.env && process.env.NODE_ENV === 'production'
     return null
   }
 
-var localStorage = typeof window === 'object' && typeof window.localStorage !== 'undefined'
+function hasLocalStorage()  {
+  try {
+    return typeof window.localStorage !== 'undefined';
+  } catch (e) {
+    // window.localStorage does not exist of we have no access
+    return false;
+  }
+}
+
+var localStorage = hasLocalStorage()
   ? window.localStorage
   : { getItem: noLS, setItem: noLS, removeItem: noLS, getAllKeys: noLS }
 


### PR DESCRIPTION
The check was not safe for ChromeExtensions. In the case of the user blocking
3rd party cookies the access of window.localStorage throws an exception, that
cased the load of the module to fail instead of fallbacking to the
"non window.localStorage" version. That leads to that the application loading this module crashes at startup.

This is how it looks when you try to access localStorage
<img width="950" alt="screen shot 2015-12-03 at 15 38 28" src="https://cloud.githubusercontent.com/assets/2647060/11563661/6332e8a8-99d5-11e5-81f9-f3689270835a.png">

Problem can be reproduced and verified by building a simple ChromeExtension that accesses window.localStorage and the enable "Block third party cookies and site data" under Content Settings in the Chrome settings menu
