### PR TITLE
Fix for rehydrating a top-level string field.

### DIFF
--- a/src/autoRehydrate.js
+++ b/src/autoRehydrate.js
@@ -22,7 +22,9 @@ module.exports = function autoRehydrate (config = {}) {
   }
 
   function checkIsObject (data, reducedState, key) {
-    if ((data.size || data.hasOwnProperty('size')) || (reducedState[key].size || reducedState[key].hasOwnProperty('size'))) {
+    if (data.size || data.hasOwnProperty('size')) {
+      return true
+    } else if (reducedState[key] && (reducedState[key].size || reducedState[key].hasOwnProperty('size'))) {
       return true
     } else if (isPlainObject(data) || isPlainObject(reducedState[key])) {
       return true


### PR DESCRIPTION
Hi,

This is one change I needed to make after upgrading from `1.4.1`. I was rehydrating a root-level string field, and `reducedState[key]` was `null`. This caused `reducedState[key].size` to throw an error. Adding this extra `(reducedState[key] &&` guard fixed the issue for me.