### PR TITLE
"setImmediate() is not available" error

### DIFF
--- a/src/persistStore.js
+++ b/src/persistStore.js
@@ -14,6 +14,7 @@ export default function persistStore (store, config = {}, onComplete) {
   const storage = config.storage || defaultStorage
   const debounce = config.debounce || false
   const shouldRestore = !config.skipRestore
+  if (typeof setImmediate === 'undefined') { const setImmediate = global.setImmediate }
 
   // initialize values
   let timeIterator = null


### PR DESCRIPTION
In an environment such as nw.js, [global.setImmediate() is not linked as setImmediate()](https://github.com/nwjs/nw.js/issues/897).