### PR TITLE
Add support for Mozilla's localForage library as a storage backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ const secondaryPersistor = persistStore(store, {storage: specialBackupStorage, s
 ```
 
 ## Storage Backends
-**localStorage** (default), react-native **AsyncStorage**, Mozilla's **[localForage](https://github.com/mozilla/localForage) library** or a conforming **custom** storage api. Custom storage API should be an object with the following methods: `setItem` `getItem` `removeItem` `getAllKeys` each with the function signature as found in [react-native AsyncStorage](http://facebook.github.io/react-native/docs/asyncstorage.html#content).
+**localStorage** (default), react-native **AsyncStorage**, Mozilla's **[localForage](https://github.com/mozilla/localForage)** library or a conforming **custom** storage api. Custom storage API should be an object with the following methods: `setItem` `getItem` `removeItem` `getAllKeys` each with the function signature as found in [react-native AsyncStorage](http://facebook.github.io/react-native/docs/asyncstorage.html#content).
 
 ```js
 import {AsyncStorage} from 'react-native'

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ const secondaryPersistor = persistStore(store, {storage: specialBackupStorage, s
 ```
 
 ## Storage Backends
-**localStorage** (default), react-native **AsyncStorage**, or a conforming **custom** storage api. Custom storage API should be an object with the following methods: `setItem` `getItem` `removeItem` `getAllKeys` each with the function signature as found in [react-native AsyncStorage](http://facebook.github.io/react-native/docs/asyncstorage.html#content).
+**localStorage** (default), react-native **AsyncStorage**, Mozilla's **[localForage](https://github.com/mozilla/localForage) library** or a conforming **custom** storage api. Custom storage API should be an object with the following methods: `setItem` `getItem` `removeItem` `getAllKeys` each with the function signature as found in [react-native AsyncStorage](http://facebook.github.io/react-native/docs/asyncstorage.html#content).
 
 ```js
 import {AsyncStorage} from 'react-native'

--- a/src/getStoredState.js
+++ b/src/getStoredState.js
@@ -7,6 +7,12 @@ export default function getStoredState (config, onComplete) {
   const deserialize = config.deserialize || defaultDeserialize
   const transforms = config.transforms || []
   const purgeMode = config.purgeMode || false
+  
+  // Add compatability with Mozilla's LocalForage library
+  if ('keys' in storage) {
+    storage.getAllKeys = (cb) => storage.keys(cb)
+  }
+
 
   let restoredState = {}
   let completionCount = 0

--- a/src/getStoredState.js
+++ b/src/getStoredState.js
@@ -7,12 +7,11 @@ export default function getStoredState (config, onComplete) {
   const deserialize = config.deserialize || defaultDeserialize
   const transforms = config.transforms || []
   const purgeMode = config.purgeMode || false
-  
+
   // Add compatability with Mozilla's LocalForage library
   if ('keys' in storage) {
     storage.getAllKeys = (cb) => storage.keys(cb)
   }
-
 
   let restoredState = {}
   let completionCount = 0

--- a/src/persistStore.js
+++ b/src/persistStore.js
@@ -16,6 +16,11 @@ export default function persistStore (store, config = {}, onComplete) {
   const debounce = config.debounce || false
   const shouldRestore = !config.skipRestore
 
+  // Add compatability with Mozilla's LocalForage library
+  if ('keys' in storage) {
+    storage.getAllKeys = (cb) => storage.keys(cb)
+  }
+
   // initialize values
   let timeIterator = null
   let lastState = store.getState()


### PR DESCRIPTION
This is a really quick PR to allow support for Mozilla's localForage library to be used as a drop-in storage backend.

The only thing that is needed, is that the `getAllKeys(cb)` function in localforage is called just `keys(cb)`, so i added a quick-and-dirty check to see if the function 'keys' exists then "rename" it. I was needed in both the persistStore.js and getStoredState.js files, but it's a grand total of like 3 lines in each.

I also updated the readme to add a line about its support with localForage.

I have no issues breaking the check out into another file and maybe adding a check for all of the required functions and an error if any don't exist, but i didn't want to change too much without asking first (it's a pain when a PR comes in with like 100 lines changed and no explanation why...)

Let me know!

By the way, nice choice in standard :+1: 