### PR TITLE
Update all dependencies and switch to babel 6

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,3 @@
 {
-  "stage": 0,
-  "loose": "all"
+  "presets": ["es2015", "stage-2"]
 }

--- a/constants.js
+++ b/constants.js
@@ -1,1 +1,3 @@
-module.exports = require('./lib/constants')
+import * as constants from './lib/constants'
+
+module.exports = constants

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "persist and rehydrate redux stores",
   "main": "lib/index.js",
   "scripts": {
-    "test": "standard && NODE_ENV=production mocha --compilers js:babel/register --recursive",
+    "test": "standard && NODE_ENV=production mocha --compilers js:babel-register --recursive",
     "test:watch": "npm test -- --watch",
     "clean": "rimraf lib dist",
     "build": "babel src --out-dir lib",
@@ -27,20 +27,22 @@
   "author": "rt2zz <zack@root-two.com>",
   "license": "MIT",
   "dependencies": {
-    "lodash.foreach": "^3.0.3",
-    "lodash.isplainobject": "^3.2.0"
+    "lodash.foreach": "^4.1.1",
+    "lodash.isplainobject": "^4.0.3"
   },
   "devDependencies": {
-    "babel": "^5.8.29",
-    "babel-core": "^5.8.33",
-    "babel-eslint": "^4.1.3",
-    "expect": "~1.12.2",
+    "babel-cli": "^6.6.5",
+    "babel-eslint": "^6.0.0",
+    "babel-preset-es2015": "^6.6.0",
+    "babel-preset-stage-2": "^6.5.0",
+    "babel-register": "^6.7.2",
+    "expect": "~1.16.0",
     "immutable": "^3.7.6",
-    "lodash": "^3.10.1",
-    "mocha": "~2.3.3",
-    "redux": "~3.0.4",
-    "rimraf": "~2.4.3",
-    "standard": "^5.3.1"
+    "lodash": "^4.6.1",
+    "mocha": "~2.4.5",
+    "redux": "~3.3.1",
+    "rimraf": "~2.5.2",
+    "standard": "^6.0.8"
   },
   "files": [
     "lib",

--- a/src/autoRehydrate.js
+++ b/src/autoRehydrate.js
@@ -2,7 +2,7 @@ import isPlainObject from 'lodash.isplainobject'
 import bufferActions from './bufferActions'
 import { REHYDRATE } from './constants'
 
-module.exports = function autoRehydrate (config = {}) {
+export default function autoRehydrate (config = {}) {
   return (next) => (reducer, initialState, enhancer) => {
     const rehydrationReducer = createRehydrationReducer(reducer)
 

--- a/src/bufferActions.js
+++ b/src/bufferActions.js
@@ -1,10 +1,10 @@
-var constants = require('./constants')
+import * as constants from './constants'
 
-module.exports = function bufferActions (cb) {
+export default function bufferActions (cb) {
   let active = true
   let queue = []
 
-  return next => action => {
+  return (next) => (action) => {
     if (!active) return next(action)
     if (action.type === constants.REHYDRATE) {
       active = false

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,4 +1,3 @@
-module.exports = {
-  keyPrefix: 'reduxPersist:',
-  REHYDRATE: 'persist/REHYDRATE'
-}
+export const keyPrefix = 'reduxPersist:'
+export const REHYDRATE = 'persist/REHYDRATE'
+

--- a/src/getStoredState.js
+++ b/src/getStoredState.js
@@ -1,5 +1,5 @@
 import forEach from 'lodash.foreach'
-import constants from './constants'
+import * as constants from './constants'
 import createAsyncLocalStorage from './defaults/asyncLocalStorage'
 
 export default function getStoredState (config, onComplete) {
@@ -18,9 +18,9 @@ export default function getStoredState (config, onComplete) {
 
   storage.getAllKeys((err, allKeys) => {
     if (err && process.env.NODE_ENV !== 'production') { console.warn('Error in storage.getAllKeys') }
-    let persistKeys = allKeys.filter(key => key.indexOf(constants.keyPrefix) === 0).map(key => key.slice(constants.keyPrefix.length))
+    let persistKeys = allKeys.filter((key) => key.indexOf(constants.keyPrefix) === 0).map((key) => key.slice(constants.keyPrefix.length))
     let keysToRestore = Array.isArray(purgeMode)
-      ? persistKeys.filter(key => purgeMode.indexOf(key) === -1)
+      ? persistKeys.filter((key) => purgeMode.indexOf(key) === -1)
       : purgeMode === '*' ? [] : persistKeys
 
     let restoreCount = keysToRestore.length

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,11 @@
-const createAsyncLocalStorage = require('./defaults/asyncLocalStorage')
+import createAsyncLocalStorage from './defaults/asyncLocalStorage'
+import persistStore from './persistStore'
+import autoRehydrate from './autoRehydrate'
+import getStoredState from './getStoredState'
 
-module.exports.persistStore = require('./persistStore')
-module.exports.autoRehydrate = require('./autoRehydrate')
-module.exports.getStoredState = require('./getStoredState')
-module.exports.storages = {
+const storages = {
   asyncLocalStorage: createAsyncLocalStorage('local'),
   asyncSessionStorage: createAsyncLocalStorage('session')
 }
+
+export { persistStore, autoRehydrate, getStoredState, storages }

--- a/src/persistStore.js
+++ b/src/persistStore.js
@@ -1,5 +1,5 @@
 import forEach from 'lodash.foreach'
-import constants from './constants'
+import * as constants from './constants'
 import createAsyncLocalStorage from './defaults/asyncLocalStorage'
 import getStoredState from './getStoredState'
 
@@ -99,7 +99,7 @@ export default function persistStore (store, config = {}, onComplete) {
     purgeMode = '*'
     storage.getAllKeys((err, allKeys) => {
       if (err && process.env.NODE_ENV !== 'production') { console.warn('Error in storage.getAllKeys') }
-      purge(allKeys.filter(key => key.indexOf(constants.keyPrefix) === 0).map(key => key.slice(constants.keyPrefix.length)))
+      purge(allKeys.filter((key) => key.indexOf(constants.keyPrefix) === 0).map((key) => key.slice(constants.keyPrefix.length)))
     })
   }
 

--- a/test/autoRehydrate.spec.js
+++ b/test/autoRehydrate.spec.js
@@ -5,7 +5,7 @@ import assert from 'assert'
 import { isEqual } from 'lodash'
 import Immutable from 'immutable'
 
-import { REHYDRATE } from '../constants'
+import { REHYDRATE } from '../src/constants'
 import { autoRehydrate } from '../src'
 
 const someString = 'someString'

--- a/test/mock/createMemoryStorage.js
+++ b/test/mock/createMemoryStorage.js
@@ -1,4 +1,4 @@
-import constants from '../../constants'
+import * as constants from '../../constants'
 import { mapKeys } from 'lodash'
 
 export default function createMemoryStorage (initialState) {

--- a/test/persistStore.spec.js
+++ b/test/persistStore.spec.js
@@ -1,15 +1,15 @@
 /* global it, describe */
 
 import { persistStore, getStoredState } from '../src'
-import constants from '../src/constants'
+import * as constants from '../src/constants'
 import createMemoryStorage from './mock/createMemoryStorage'
 import assert from 'assert'
 import { isEqual } from 'lodash'
 
 function createMockStore (opts) {
   return {
-    subscribe: opts.subscribe || () => {},
-    dispatch: opts.dispatch || () => {},
+    subscribe: opts.subscribe || function () {},
+    dispatch: opts.dispatch || function () {},
     getState: () => {
       return opts.mockState ? {...opts.mockState} : {}
     }


### PR DESCRIPTION
This PR updates all dependencies to the latest version. Most changes are necessary because babel changed quite a bit with version 6. `babel-preset-stage-2` is needed for the spread operator in `persistStore.spec.js`.

There are two stylistic changes needed to satisfy standardjs:

```js
// Wrong
const foo = bar || () => {};

// Right
const foo = bar || function () {};

// Wrong (missing parenthesis)
return next => foo;

// Right
return (next) => foo;
```