### PR TITLE
Cover null cases in checkIfPlain()

### DIFF
--- a/src/autoRehydrate.js
+++ b/src/autoRehydrate.js
@@ -51,6 +51,7 @@ export default function autoRehydrate (config = {}) {
 
 function checkIfPlain (a, b) {
   // isPlainObject + duck type not immutable
+  if (!a || !b) return false
   if (typeof a !== 'object' || typeof b !== 'object') return false
   if (typeof a.mergeDeep === 'function' || typeof b.mergeDeep === 'function') return false
   if (!isPlainObject(a) || !isPlainObject(b)) return false


### PR DESCRIPTION
Some of my rehydrated state is null, and it's causing an error during rehydration. This change fixes things for me