### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ are hot off the presses, feedback welcome!
 Basic usage requires adding three lines to a traditional redux application:
 ```js
 import {persistStore, autoRehydrate} from 'redux-persist'
-const store = createStore(reducer, null, autoRehydrate())
+const store = createStore(reducer, undefined, autoRehydrate())
 persistStore(store)
 ```
 For per reducer rehydration logic, you can opt-in by adding a handler to your reducer:


### PR DESCRIPTION
If you pass in null as the initialState of createStore, then you cannot define your reducer like this:

`export function myStore(state = {}, action) {` because initialState wins out. 
If initialState is undefined though, then the initial state in your reducer wins. 
This is simply a redux issue that I'm bringing up and hence making this PR. I'll reference an issue from Redux:
https://github.com/reactjs/redux/issues/1189