### PR TITLE
fixing NaN output in preRehydrateActions log

### DIFF
--- a/src/autoRehydrate.js
+++ b/src/autoRehydrate.js
@@ -50,6 +50,6 @@ function logPreRehydrate (preRehydrateActions) {
       redux-persist/autoRehydrate: %d actions were fired before rehydration completed. This can be a symptom of a race
       condition where the rehydrate action may overwrite the previously affected state. Consider running these actions
       after rehydration:
-    `, preRehydrateActions)
+    `, preRehydrateActions.length)
   }
 }


### PR DESCRIPTION
Fixes output of preRehydrate actions returning NaN