### PR TITLE
Allow for any type of root level state

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# What about redux-persist?
+This is a fork of redux-persist published as `redux-persist-2` until the PR https://github.com/rt2zz/redux-persist/pull/113 gets merged.
+
 # Redux Persist
 Persist and rehydrate a redux store.
 

--- a/src/autoRehydrate.js
+++ b/src/autoRehydrate.js
@@ -2,6 +2,8 @@ import { REHYDRATE } from './constants'
 import isStatePlainEnough from './utils/isStatePlainEnough'
 
 export default function autoRehydrate (config = {}) {
+  config.stateReconciler = config.stateReconciler || defaultStateReconciler
+
   return (next) => (reducer, initialState, enhancer) => {
     return next(createRehydrationReducer(reducer), initialState, enhancer)
   }
@@ -19,26 +21,8 @@ export default function autoRehydrate (config = {}) {
 
         let inboundState = action.payload
         let reducedState = reducer(state, action)
-        let newState = {...reducedState}
 
-        Object.keys(inboundState).forEach((key) => {
-          // if initialState does not have key, skip auto rehydration
-          if (!state.hasOwnProperty(key)) return
-
-          // if reducer modifies substate, skip auto rehydration
-          if (state[key] !== reducedState[key]) {
-            if (config.log) console.log('redux-persist/autoRehydrate: sub state for key `%s` modified, skipping autoRehydrate.', key)
-            newState[key] = reducedState[key]
-            return
-          }
-
-          // otherwise take the inboundState
-          if (isStatePlainEnough(inboundState[key]) && isStatePlainEnough(state[key])) newState[key] = {...state[key], ...inboundState[key]} // shallow merge
-          else newState[key] = inboundState[key] // hard set
-
-          if (config.log) console.log('redux-persist/autoRehydrate: key `%s`, rehydrated to ', key, newState[key])
-        })
-        return newState
+        return config.stateReconciler(state, inboundState, reducedState, config.log)
       }
     }
   }
@@ -52,4 +36,27 @@ function logPreRehydrate (preRehydrateActions) {
       after rehydration:
     `, preRehydrateActions.length)
   }
+}
+
+function defaultStateReconciler (state, inboundState, reducedState, logger) {
+  let newState = {...reducedState}
+
+  Object.keys(inboundState).forEach((key) => {
+    // if initialState does not have key, skip auto rehydration
+    if (!state.hasOwnProperty(key)) return
+
+    // if reducer modifies substate, skip auto rehydration
+    if (state[key] !== reducedState[key]) {
+      if (logger) console.log('redux-persist/autoRehydrate: sub state for key `%s` modified, skipping autoRehydrate.', key)
+      newState[key] = reducedState[key]
+      return
+    }
+
+    // otherwise take the inboundState
+    if (isStatePlainEnough(inboundState[key]) && isStatePlainEnough(state[key])) newState[key] = {...state[key], ...inboundState[key]} // shallow merge
+    else newState[key] = inboundState[key] // hard set
+
+    if (logger) console.log('redux-persist/autoRehydrate: key `%s`, rehydrated to ', key, newState[key])
+  })
+  return newState
 }

--- a/src/createPersistor.js
+++ b/src/createPersistor.js
@@ -1,6 +1,5 @@
 import * as constants from './constants'
 import createAsyncLocalStorage from './defaults/asyncLocalStorage'
-import isStatePlainEnough from './utils/isStatePlainEnough'
 import stringify from 'json-stringify-safe'
 import { forEach } from 'lodash'
 
@@ -75,7 +74,7 @@ export default function createPersistor (store, config) {
           let value = transforms.reduceRight((interState, transformer) => {
             return transformer.out(interState, key)
           }, data)
-          state = defaultStateSetter(state, key, value)
+          state = stateSetter(state, key, value)
         } catch (err) {
           if (process.env.NODE_ENV !== 'production') console.warn(`Error rehydrating data for key "${key}"`, subState, err)
         }
@@ -163,7 +162,7 @@ function defaultStateGetter (state, key) {
   return state[key]
 }
 
-function defaultStateSetter(state, key, value) {
+function defaultStateSetter (state, key, value) {
   state[key] = value
   return state
 }


### PR DESCRIPTION
This addresses issue (#64), when you have an immutable object as the root state. 

The `redux-persist-immutable-state` package provides the functions for actually iterating over an immutable root state as well as getting and setting keys.

Usage of redux-persist-immutable-state:

```
import { stateIterator, stateGetter, stateSetter, 
         stateReconciler, lastStateInit } from 'redux-persist-immutable-state';

persistStore(state, {
  transforms: [reduxPersistImmutable], 
  stateIterator: stateIterator,  
  stateGetter: stateGetter, stateSetter: stateSetter,
  lastStateInit: lastStateInit
})
```

I've spent some time benchmarking the persisting of new data on state changes, as well as rehydrating the state from localStorage. Here are the results:
![chart](https://cloud.githubusercontent.com/assets/1128559/15913907/d12ac1c8-2d91-11e6-8964-a6c8242587eb.png)

The skeleton around those benchmarks is here: https://github.com/rufman/benchmark-redux-persist
If you want to run the tests yourself just clone https://github.com/rufman/redux-persist into the `lib`  directory of `benchmark-redux-persist` and run `webpack`. Then `open index.html` and run the tests.