### PR TITLE
Guarded getAllKeys, should return on error and do not proceed further…

### DIFF
--- a/src/defaults/asyncLocalStorage.js
+++ b/src/defaults/asyncLocalStorage.js
@@ -10,7 +10,7 @@ const noStorage = process && process.env && process.env.NODE_ENV === 'production
 
 function hasLocalStorage () {
   try {
-    return typeof window === 'object' && typeof window.localStorage !== 'undefined'
+    return typeof window === 'object' && typeof window.localStorage !== 'undefined' && window.localStorage !== null
   } catch (e) { return false }
 }
 

--- a/src/getStoredState.js
+++ b/src/getStoredState.js
@@ -17,9 +17,9 @@ export default function getStoredState (config, onComplete) {
   let completionCount = 0
 
   storage.getAllKeys((err, allKeys) => {
-    if (err && process.env.NODE_ENV !== 'production') {
-      console.warn('redux-persist/getStoredState: Error in storage.getAllKeys')
-      return false
+    if (err) {
+      if (process.env.NODE_ENV !== 'production') console.warn('redux-persist/getStoredState: Error in storage.getAllKeys')
+      return
     }
 
     let persistKeys = allKeys.filter((key) => key.indexOf(constants.keyPrefix) === 0).map((key) => key.slice(constants.keyPrefix.length))


### PR DESCRIPTION
… to throw at next line. Also improved localStorage detection.

I have embedded my app in a webview on Android, and in a normal use case it has `window.localStorage` but it is a null. So such situation should not be IMHO treated as having a localStorage available. Personally I would just shorten the check from

`typeof window.localStorage !== 'undefined' && window.localStorage !== null`

to just `window.localStorage` but wanted to follow your convention here.

Fixes #122 