### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,8 +127,8 @@ Transforms allow for arbitrary state transforms before saving and during rehydra
 import { createTransform, persistStore } from 'redux-persist'
 
 let myTransform = createTransform(
-  (inboundState) => specialSerialize(inboundState),
-  (outboundState) => specialDeserialize(outboundState),
+  (inboundState, action) => specialSerialize(inboundState, action),
+  (outboundState, action) => specialDeserialize(outboundState, action),
   {whitelist: ['specialReducer']}
 )
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ persistStore(store, config, callback).purge(['someReducer']) //or .purgeAll()
   - This is a store enhancer that will automatically shallow merge the persisted state for each key. Additionally it queues any actions that are dispatched before rehydration is complete, and fires them after rehydration is finished.
 
 #### `constants`
-  - `import constants from 'redux-persist/constants'`. This includes rehydration action types, and other relevant constants.
+  - `import * as constants from 'redux-persist/constants'`. This includes rehydration action types, and other relevant constants.
 
 ## Alternate Usage
 #### getStoredState / createPersistor


### PR DESCRIPTION
Small change to the readme:

-  `import constants from 'redux-persist/constants'` will just return `undefined` as there seems to be no default export in `constants.js`

- update `Transforms` part to make clear reducers are passed in