### PR TITLE
Hotfix: localForage -> getAllKeys assinging

### DIFF
--- a/src/createPersistor.js
+++ b/src/createPersistor.js
@@ -22,7 +22,9 @@ export default function createPersistor (store, config) {
 
   // storage with keys -> getAllKeys for localForage support
   let storage = config.storage || createAsyncLocalStorage('local')
-  if (storage.keys && !storage.getAllKeys) storage = {...storage, getAllKeys: storage.keys}
+  if (storage.keys && !storage.getAllKeys) {
+    storage.getAllKeys = storage.keys
+  }
 
   // initialize stateful values
   let lastState = stateInit


### PR DESCRIPTION
Assigning the additional key to the storage object kills the some of the localForage functionality, because the prototype methods are not carried over. I don't see any benefit from assigning `getAllKeys` anyway, so this shouldn't affect anything else.

For a bit of background on the problems we were having... On Safari the storage adapter was falling back to webSQL which then failed because it lost some of it's functionality, particularly self.ready was undefined.

`TypeError: self.ready is not a function. (In 'self.ready()', 'self.ready' is undefined)`

https://github.com/localForage/localForage/blob/master/src/drivers/websql.js#L151