### PR TITLE
WIP: use storage.clear when available

### DIFF
--- a/src/purgeStoredState.js
+++ b/src/purgeStoredState.js
@@ -10,14 +10,20 @@ export default function purgeStoredState (config, keys) {
 
   if (typeof keys === 'undefined') { // if keys is not defined, purge all keys
     return new Promise((resolve, reject) => {
-      storage.getAllKeys((err, allKeys) => {
-        if (err && process.env.NODE_ENV !== 'production') {
-          console.warn('redux-persist: error during purgeStoredState in storage.getAllKeys')
-          reject(err)
-        } else {
-          resolve(purgeStoredState(config, allKeys.filter((key) => key.indexOf(keyPrefix) === 0).map((key) => key.slice(keyPrefix.length))))
-        }
-      })
+      if (storage.clear) { // if the storage has `clear` method, use it.
+        storage.clear(() => {
+          resolve(0)
+        })
+      } else {
+        storage.getAllKeys((err, allKeys) => {
+          if (err && process.env.NODE_ENV !== 'production') {
+            console.warn('redux-persist: error during purgeStoredState in storage.getAllKeys')
+            reject(err)
+          } else {
+            resolve(purgeStoredState(config, allKeys.filter((key) => key.indexOf(keyPrefix) === 0).map((key) => key.slice(keyPrefix.length))))
+          }
+        })
+      }
     })
   } else { // otherwise purge specified keys
     return Promise.all(keys.map((key) => {


### PR DESCRIPTION
`persistor.purge()` is kind of slow, i suggest if the storage implemented a `clear` method, just use it.

for now, `localStorage`, `sessionStorage`, `AsyncStorage` and `localForage` all have `clear()`
