### PR TITLE
Attempt to set/get item from localstorage

### DIFF
--- a/src/defaults/asyncLocalStorage.js
+++ b/src/defaults/asyncLocalStorage.js
@@ -9,9 +9,17 @@ const noStorage = process && process.env && process.env.NODE_ENV === 'production
   }
 
 function hasLocalStorage () {
+  let storageExists
   try {
-    return typeof window === 'object' && !!window.localStorage
+    storageExists = (typeof window === 'object' && !!window.localStorage)
+    if (storageExists) {
+      const testKey = 'redux-persist localStorage test'
+      window.localStorage.setItem(testKey, true)
+      window.localStorage.getItem(testKey)
+      window.localStorage.removeItem(testKey)
+    }
   } catch (e) { return false }
+  return storageExists
 }
 
 function hasSessionStorage () {


### PR DESCRIPTION
Fixes #204 

In Windows environments, it's possible for browsers to have a localStorage and yet not have access to it.  This ends up throwing an `Access is denied` error when attempting to get or set from localStorage.  

This change adds some additional safety checks into `hasLocalStorage` to set, get, and remove a test item inside the try block.  