### PR TITLE
add config.serialize as boolean

### DIFF
--- a/redux-persist.js.flow
+++ b/redux-persist.js.flow
@@ -21,6 +21,7 @@ declare module 'redux-persist' {
     storage?: Storage,
     transforms?: Array<Object>,
     debounce?: number,
+    serialize?: boolean,
   }
   declare type Purge = (keys: Array<string>) => void
   declare type Rehydrate = (incoming: Object, options: { serial: boolean }) => void
@@ -31,7 +32,7 @@ declare module 'redux-persist' {
     resume: () => void,
   }
   declare type OnComplete = (err?: any, result?: Object) => void
-  
+
   declare type AutoRehydrate = Function
   declare type CreatePersistor = (store: Store, config: Config) => Persistor
   declare type CreateTransform = (in: TransformIn, out: TransformOut, config: TransformConfig) => Transform


### PR DESCRIPTION
**breaking change**

This is a proposed breaking change for v4 which will turn the (undocumented) serialize & deserialize config options from functions into a single serialize option as a boolean.

This simplifies the api, makes disabling serialization easier, and if pluggable serialization is needed it can (and should) be done through the transforms api.