### PR TITLE
use a different immutable signature function

### DIFF
--- a/src/utils/isStatePlainEnough.js
+++ b/src/utils/isStatePlainEnough.js
@@ -4,7 +4,7 @@ export default function isStatePlainEnough (a) {
   // isPlainObject + duck type not immutable
   if (!a) return false
   if (typeof a !== 'object') return false
-  if (typeof a.mergeDeep === 'function') return false
+  if (typeof a.asMutable === 'function') return false
   if (!isPlainObject(a)) return false
   return true
 }


### PR DESCRIPTION
There are immutable libs like https://github.com/rtfeldman/seamless-immutable which don't specify mergeDeep(). Instead, using asMutable() does not only sound more significant here, it is also part of facebook's immutable, and probably avoids unintended behavior with non-immutable objects implementing the generic name mergeDeep().