### PR TITLE
autoRehydrate() does object comparison correctly using JSON.stringify

### DIFF
--- a/src/autoRehydrate.js
+++ b/src/autoRehydrate.js
@@ -58,7 +58,7 @@ function defaultStateReconciler (state, inboundState, reducedState, log) {
     }
 
     // if reducer modifies substate, skip auto rehydration
-    if (state[key] !== reducedState[key]) {
+    if (JSON.stringify(state[key]) !== JSON.stringify(reducedState[key])) {
       if (log) console.log('redux-persist/autoRehydrate: sub state for key `%s` modified, skipping autoRehydrate.', key)
       newState[key] = reducedState[key]
       return


### PR DESCRIPTION
Right now autoRehydrate uses a comparison check of `state[key] !== reducedState[key]` to see if the reducer changes the substate. The !== operator will always return true when comparing two objects.

This implementation converts the objects to strings using JSON.stringify and then does the comparison, which allows for a true deep comparison of the objects just based on content.

This may not be the best way to do object comparison but it worked for me.