### PR TITLE
Fix Persister.purge() typescript definition

### DIFF
--- a/type-definitions/index.d.ts
+++ b/type-definitions/index.d.ts
@@ -38,7 +38,7 @@ declare module "redux-persist/lib/interfaces" {
   }
 
   export  interface Persistor {
-    purge: (keys: string[]) => void;
+    purge: (keys?: string[]) => void;
     rehydrate: (incoming: Object, options: { serial: boolean }) => void;
     pause: () => void;
     resume: () => void;


### PR DESCRIPTION
Persistor.purge() can take no arguments as well as keys, meaning that all keys should be purged.