### PR TITLE
Remove key check for autoRehydrate.js

### DIFF
--- a/src/autoRehydrate.js
+++ b/src/autoRehydrate.js
@@ -48,8 +48,6 @@ function defaultStateReconciler (state, inboundState, reducedState, log) {
   let newState = {...reducedState}
 
   Object.keys(inboundState).forEach((key) => {
-    // if initialState does not have key, skip auto rehydration
-    if (!state.hasOwnProperty(key)) return
 
     // if initial state is an object but inbound state is null/undefined, skip
     if (typeof state[key] === 'object' && !inboundState[key]) {

--- a/src/autoRehydrate.js
+++ b/src/autoRehydrate.js
@@ -48,7 +48,6 @@ function defaultStateReconciler (state, inboundState, reducedState, log) {
   let newState = {...reducedState}
 
   Object.keys(inboundState).forEach((key) => {
-
     // if initial state is an object but inbound state is null/undefined, skip
     if (typeof state[key] === 'object' && !inboundState[key]) {
       if (log) console.log('redux-persist/autoRehydrate: sub state for key `%s` is falsy but initial state is an object, skipping autoRehydrate.', key)

--- a/test/autoRehydrate.spec.js
+++ b/test/autoRehydrate.spec.js
@@ -48,10 +48,10 @@ test('can rehydrating immutable state', (t) => {
   t.truthy(state.immutableSpace.equals(immutableData))
 })
 
-test('does not rehydrate unknown state keys', (t) => {
+test('does rehydrate unknown state keys', (t) => {
   let store = configureStore(createReducer())
   let someData = 1
   store.dispatch(rehydrate({someData}))
   let state = store.getState()
-  t.truthy(state.someData === undefined)
+  t.truthy(state.someData === 1)
 })


### PR DESCRIPTION
In order to resolve #130 **if** it is unintended that asynchronously loaded reducers will not be hydrated by `autoRehydrate` store enhancer. Removes the check for persisted keys to exist in Redux initial state.