### PR TITLE
documentation anchor fix

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -1,13 +1,13 @@
 ## Redux Persist API
 **core**
 - [persistStore(store, config, callback)](#persiststorestore-config-callback) -> persistor
-- [autoRehydrate()](#autorehydrate) -> redux store enhancer  
+- [autoRehydrate()](#autorehydrate) -> redux store enhancer
 
 **advanced**
 - [getStoredState(config, callback)](#getstoredstateconfig-callback) -> Promise -> State
 - [createPersistor(store, config)](#createpersistorstore-config) -> Persistor
 - [createTransform(in, out, config)](#createtransformin-out-config) -> Transform
-- [purgeStoredState(config, keys)](#purgestoredstate-config-keys) -> Promise -> void  
+- [purgeStoredState(config, keys)](#purgestoredstateconfig-keys) -> Promise -> void  
 
 **objects**
 - [config](#config-)


### PR DESCRIPTION
# Context

This PR fixes a small issue with the documentation, where the `purgeStoredState` method anchor wasn't working correctly

## Media

![gif](http://recordit.co/baq3d3wCmS.gif)