### PR TITLE
[docs] purgeAll -> purge

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -80,7 +80,7 @@ purgeStoredState({storage: AsyncStorage}, ['someReducer']).then(() => {
 #### persistor {}
 ```js
 persistor.rehydrate(incomingState, {serial: true})
-persistor.purgeAll()
+persistor.purge()
 persistor.pause()
 persistor.resume()
 ```


### PR DESCRIPTION
Seems like `purgeAll` is not present in the API and `purge` without argument purges all keys.