### PR TITLE
Remove use of Reflect to delete key

### DIFF
--- a/src/persistStore.js
+++ b/src/persistStore.js
@@ -25,7 +25,7 @@ export default function persistStore (store, config = {}, onComplete) {
         // do not persist state for purgeKeys
         if (purgeKeys) {
           if (purgeKeys === '*') restoredState = {}
-          else purgeKeys.forEach((key) => Reflect.deleteProperty(restoredState, key))
+          else purgeKeys.forEach((key) => delete restoredState[key])
         }
 
         store.dispatch(rehydrateAction(restoredState, err))


### PR DESCRIPTION
This removes use of Reflect API to delete persistedState object key, since it's been reporting error under certain evironments. See #263 