### PR TITLE
Use typeof to check for Node.js process existance

### DIFF
--- a/src/defaults/asyncLocalStorage.js
+++ b/src/defaults/asyncLocalStorage.js
@@ -1,7 +1,7 @@
 import { NODE_ENV } from '../env'
 
 const genericSetImmediate = typeof setImmediate === 'undefined' ? global.setImmediate : setImmediate
-const nextTick = process && process.nextTick ? process.nextTick : genericSetImmediate
+const nextTick = typeof process !== 'undefined' && process.nextTick ? process.nextTick : genericSetImmediate
 
 const noStorage = NODE_ENV === 'production'
   ? () => { /* noop */ return null }


### PR DESCRIPTION
This fixes #297 

In webpack builds this will get minified as follows:

`c=process`

which leads to a reference error (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Not_defined).

Thus I rewrote it as:

`typeof process !== 'undefined'`