### PR TITLE
Export consts as string literals

### DIFF
--- a/type-definitions/index.d.ts
+++ b/type-definitions/index.d.ts
@@ -71,8 +71,8 @@ declare module "redux-persist" {
 }
 
 declare module "redux-persist/constants" {
-  export const KEY_PREFIX: string;
-  export const REHYDRATE: string;
+  export const KEY_PREFIX = 'reduxPersist:';
+  export const REHYDRATE = 'persist/REHYDRATE';
 }
 
 declare module "redux-persist/storages" {


### PR DESCRIPTION
Instead of exporting them as generic `string`s, I propose they are exported as string literals (https://www.typescriptlang.org/docs/handbook/advanced-types.html#string-literal-types). That way users can do discriminated unions (https://www.typescriptlang.org/docs/handbook/advanced-types.html#discriminated-unions).