### PR TITLE
Add redux-persist-filesystem-storage as available storage engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ const secondaryPersistor = createPersistor(store, {storage: specialBackupStorage
 - **sessionStorage**
 - **[localForage](https://github.com/mozilla/localForage)** (recommended) web, see usage below
 - **[AsyncStorage](http://facebook.github.io/react-native/docs/asyncstorage.html#content)** for react-native
+- **[redux-persist-filesystem-storage](https://github.com/robwalkerco/redux-persist-filesystem-storage)** for use in react-native Android to mitigate storage size limitations ([#199](https://github.com/rt2zz/redux-persist/issues/199), [284](https://github.com/rt2zz/redux-persist/issues/284))
 - **[redux-persist-node-storage](https://github.com/pellejacobs/redux-persist-node-storage)** for use in nodejs environments.
 - **custom** any conforming storage api implementing the following methods: `setItem` `getItem` `removeItem` `getAllKeys`. [[example](https://github.com/facebook/react-native/blob/master/Libraries/Storage/AsyncStorage.js)]
 


### PR DESCRIPTION
Due to the limitation on React Native Android of the amount of data that can be stored in a single persisted reducer, I have created an alternative storage implementation that uses the filesystem to persist the data rather than AsyncStorage.