### PR TITLE
Do not mention setImmediate in the code alone, so its polyfill doesnt…

### DIFF
--- a/src/defaults/asyncLocalStorage.js
+++ b/src/defaults/asyncLocalStorage.js
@@ -1,4 +1,4 @@
-const localSetImmediate = typeof setImmediate === 'undefined' ? global.setImmediate : setImmediate
+import setImmediate from '../utils/setImmediate'
 
 let noStorage = () => { /* noop */ return null }
 if (process.env.NODE_ENV !== 'production') {
@@ -57,7 +57,7 @@ export default function (type, config) {
           for (var i = 0; i < storage.length; i++) {
             keys.push(storage.key(i))
           }
-          localSetImmediate(() => {
+          setImmediate(() => {
             cb && cb(null, keys)
             resolve(keys)
           })
@@ -71,7 +71,7 @@ export default function (type, config) {
       return new Promise((resolve, reject) => {
         try {
           var s = storage.getItem(key)
-          localSetImmediate(() => {
+          setImmediate(() => {
             cb && cb(null, s)
             resolve(s)
           })
@@ -85,7 +85,7 @@ export default function (type, config) {
       return new Promise((resolve, reject) => {
         try {
           storage.setItem(key, string)
-          localSetImmediate(() => {
+          setImmediate(() => {
             cb && cb(null)
             resolve()
           })
@@ -99,7 +99,7 @@ export default function (type, config) {
       return new Promise((resolve, reject) => {
         try {
           storage.removeItem(key)
-          localSetImmediate(() => {
+          setImmediate(() => {
             cb && cb(null)
             resolve()
           })

--- a/src/persistStore.js
+++ b/src/persistStore.js
@@ -1,9 +1,7 @@
 import { REHYDRATE } from './constants'
 import getStoredState from './getStoredState'
 import createPersistor from './createPersistor'
-
-// try to source setImmediate as follows: setImmediate (global) -> global.setImmediate -> setTimeout(fn, 0)
-const genericSetImmediate = typeof setImmediate === 'undefined' ? global.setImmediate || function (fn) { return setTimeout(fn, 0) } : setImmediate
+import setImmediate from './utils/setImmediate'
 
 export default function persistStore (store, config = {}, onComplete) {
   // defaults
@@ -19,7 +17,7 @@ export default function persistStore (store, config = {}, onComplete) {
 
   // restore
   if (shouldRestore) {
-    genericSetImmediate(() => {
+    setImmediate(() => {
       getStoredState(config, (err, restoredState) => {
         // do not persist state for purgeKeys
         if (purgeKeys) {
@@ -31,7 +29,7 @@ export default function persistStore (store, config = {}, onComplete) {
         complete(err, restoredState)
       })
     })
-  } else genericSetImmediate(complete)
+  } else setImmediate(complete)
 
   function complete (err, restoredState) {
     persistor.resume()

--- a/src/utils/setImmediate.js
+++ b/src/utils/setImmediate.js
@@ -1,0 +1,3 @@
+const setImmediate = typeof global.setImmediate !== 'undefined' ? global.setImmediate : setTimeout
+
+export default setImmediate


### PR DESCRIPTION
… get included in the bundle (fixes #333 and #329)

@rt2zz Please review if it satisfies library's requirements.

By omitting direct mention of `setImmediate` library went down a little bit in terms of size:
```
redux-persist.js - 46K -> 33K
redux-persist.min.js - 16K -> 12K
```

Still would like to somehow omit also `global` polyfill, as its unneccessary too, but have no idea how to omit both at once and still provide expected functionality. At least `global`'s is pretty small.