### PR TITLE
Make redux-persist/constants and redux-persist/storages use the right…

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -1,1 +1,0 @@
-module.exports = require('./lib/constants')

--- a/constants/package.json
+++ b/constants/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "redux-persist/constants",
+  "private": true,
+  "main": "../lib/constants.js",
+  "module": "../es/constants.js",
+  "jsnext:main": "../es/constants.js"
+}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
   "scripts": {
-    "test": "standard 'src/**/*.js' 'test/**/*.js' storages.js constants.js && BABEL_ENV=commonjs ava --esnext",
+    "test": "standard 'src/**/*.js' 'test/**/*.js' && BABEL_ENV=commonjs ava --esnext",
     "test:watch": "npm test -- --watch",
     "copy-types": "cp -r type-definitions/ lib/ && cp -r type-definitions/ es/",
     "clean": "rimraf lib dist es",

--- a/storages.js
+++ b/storages.js
@@ -1,1 +1,0 @@
-module.exports = require('./lib/defaultStorages')

--- a/storages/package.json
+++ b/storages/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "redux-persist/storages",
+  "private": true,
+  "main": "../lib/defaultStorages.js",
+  "module": "../es/defaultStorages.js",
+  "jsnext:main": "../es/defaultStorages.js"
+}


### PR DESCRIPTION
… builds

Basically previous solution forced bundlers to use files from the `lib` directory which has modules transpiled, so it prevented tree-shaking for example.

More can be found [here](https://github.com/redux-saga/redux-saga/pull/895) and in mentioned issues there.