### PR TITLE
Guard check against global, so non-babel users can use the lib withou…

### DIFF
--- a/src/utils/setImmediate.js
+++ b/src/utils/setImmediate.js
@@ -1,3 +1,3 @@
-const setImmediate = typeof global.setImmediate !== 'undefined' ? global.setImmediate : setTimeout
+const setImmediate = typeof global !== 'undefined' && typeof global.setImmediate !== 'undefined' ? global.setImmediate : setTimeout
 
 export default setImmediate


### PR DESCRIPTION
…t need for polyfilling (fixes #329)