### PR TITLE
Immediately remove store

### DIFF
--- a/src/createPersistor.js
+++ b/src/createPersistor.js
@@ -52,11 +52,10 @@ export default function createPersistor (store, config) {
           return
         }
 
-        let key = storesToProcess[0]
+        let key = storesToProcess.shift()
         let storageKey = createStorageKey(key)
         let endState = transforms.reduce((subState, transformer) => transformer.in(subState, key), stateGetter(store.getState(), key))
         if (typeof endState !== 'undefined') storage.setItem(storageKey, serializer(endState), warnIfSetError(key))
-        storesToProcess.shift()
       }, debounce)
     }
 


### PR DESCRIPTION
When serialization throws, we otherwise end up with an infinite retry.

We're seeing a very obscure serialization issue in `json-stringify-safe` on a production app, where two old android devices throw. We're having trouble reproducing this, and we're still investigating. However, every time the serialization throws, the `store` is not removed from the `storesToProcess` list and serialization is retried in the subsequent `timeIterator` call. This goes on indefinitely, amplifying the total amount of underlying serialization issues we're seeing.