### PR TITLE
Fix Flow for Purge()

### DIFF
--- a/type-definitions/index.js.flow
+++ b/type-definitions/index.js.flow
@@ -25,7 +25,7 @@ declare type Config = {
   serialize?: boolean,
   keyPrefix?: string,
 }
-declare type Purge = (keys: Array<string>) => void
+declare type Purge = (keys?: Array<string>) => void
 declare type Rehydrate = (incoming: Object, options: { serial: boolean }) => void
 declare type Persistor = {
   purge: Purge,


### PR DESCRIPTION
Fix flow type for purge() where the argument `keys` is optional.