### PR TITLE
Note that custom storage must support callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ const secondaryPersistor = createPersistor(store, {storage: specialBackupStorage
 - **[AsyncStorage](http://facebook.github.io/react-native/docs/asyncstorage.html#content)** for react-native
 - **[redux-persist-filesystem-storage](https://github.com/robwalkerco/redux-persist-filesystem-storage)** for use in react-native Android to mitigate storage size limitations ([#199](https://github.com/rt2zz/redux-persist/issues/199), [284](https://github.com/rt2zz/redux-persist/issues/284))
 - **[redux-persist-node-storage](https://github.com/pellejacobs/redux-persist-node-storage)** for use in nodejs environments.
-- **custom** any conforming storage api implementing the following methods: `setItem` `getItem` `removeItem` `getAllKeys`. [[example](https://github.com/facebook/react-native/blob/master/Libraries/Storage/AsyncStorage.js)]
+- **custom** any conforming storage api implementing the following methods: `setItem` `getItem` `removeItem` `getAllKeys`. (**NB**: These methods must support callbacks, not promises.) [[example](https://github.com/facebook/react-native/blob/master/Libraries/Storage/AsyncStorage.js)]
 
 ```js
 // sessionStorage


### PR DESCRIPTION
Spent about an hour trying to figure out why redux-persist wasn't working, and after plenty of debugging I realised it was because custom storage modules need to use callbacks, not promises. Added this factoid to the readme.