### PR TITLE
Call resume even if rehydrateAction throws an exception.

### DIFF
--- a/src/persistStore.js
+++ b/src/persistStore.js
@@ -30,8 +30,6 @@ export default function persistStore (store, config = {}, onComplete) {
         }
         try {
           store.dispatch(rehydrateAction(restoredState, err))
-        } catch (err) {
-          console.log(err)
         } finally {
           complete(err, restoredState)
         }

--- a/src/persistStore.js
+++ b/src/persistStore.js
@@ -28,9 +28,13 @@ export default function persistStore (store, config = {}, onComplete) {
           if (purgeKeys === '*') restoredState = {}
           else purgeKeys.forEach((key) => delete restoredState[key])
         }
-
-        store.dispatch(rehydrateAction(restoredState, err))
-        complete(err, restoredState)
+        try {
+          store.dispatch(rehydrateAction(restoredState, err))
+        } catch (err) {
+          console.log(err)
+        } finally {
+          complete(err, restoredState)
+        }
       })
     })
   } else setImmediate(complete)


### PR DESCRIPTION
Tracked down a bug in my code where an exception was being thrown as a consequence of a persisted state being loaded, this stopped redux persist working.

Turned out that the persist store was being left in a paused state.

Quite a lot can happen as a result of `store.dispatch(rehydrateAction(restoredState, err))`, so I think we should make sure that the `persistStore` is resumed if there is an exception.

I thought it was also useful to trace the error - but this is perhaps less of an issue.