### PR TITLE
Fix typings for AsyncStorage

### DIFF
--- a/type-definitions/index.d.ts
+++ b/type-definitions/index.d.ts
@@ -3,8 +3,14 @@ declare module "redux-persist" {
 
   export interface Storage {
     setItem(key: string, value: any, onComplete?: OnComplete<any>): Promise<any>;
-    getItem<Result>(key: string, onComplete?: OnComplete<Result>): Promise<Result>;
+    getItem<Result>(
+      key: string,
+      onComplete?: OnComplete<Result | string>
+    ): Promise<Result | string>;
     removeItem(key: string, onComplete?: OnComplete<any>): Promise<any>;
+    getAllKeys?<Result>(
+      callback?: (error?: Error, keys?: string[]) => void
+    ): Promise<string[]>;
     getAllKeys?<Result>(onComplete?: OnComplete<Result>): Promise<Result>;
     keys?: (...args: any[]) => any;
     [key: string]: any; // In case Storage object has some other (private?) methods and properties.


### PR DESCRIPTION
The current typings don't allow for React Native's AsyncStorage as the signatures for `getItem` and `getAllKeys` are different.

This PR adds support for React Native's Async Storage by changing the typings.