### PR TITLE
(persistStore): Add promise support

### DIFF
--- a/test/persistStore.spec.js
+++ b/test/persistStore.spec.js
@@ -87,3 +87,17 @@ test.cb('processes adhoc rehydrate with serial: false', (t) => {
     throw new Error('timeout')
   }, 10000)
 })
+
+test('Returns state to persistStore promise', (t) => {
+  let store = createMockStore({
+    mockState: {foo: 1, bar: 2},
+    dispatch: () => {}
+  })
+
+  let seedState = {foo: 3, bar: 4}
+  return persistStore(store, { storage: createMemoryStorage(seedState) }).promise.then(({ err, state }) => {
+    t.ifError(err, 'persistStore errored')
+    t.deepEqual(state, seedState)
+    t.pass()
+  })
+})


### PR DESCRIPTION
Hi! I try to find a solution for Delayed render while `redux-persist` restore app state. Got this - https://github.com/rt2zz/redux-persist/blob/master/docs/recipes.md.

For now, my `store.js` is so big, I want to keep store initialization in the separate file.
I thought export `promise` property from `persistStore` would be a great feature like a `onComplete` callback.

#### store.js
```js
// ...

export const persistor = persistStore(store, { ... })

export default store
```

#### App.js
```js
// ...
import store, { persistor } from './store'

export default class App extends PureComponent {
  state = {
    loaded: false,
  }

  componentWillMount() {
    persistor.promise.then(() => {
      this.setState({ loaded: true })
    })
  }

  render() {
    if (!this.state.loaded) {
      return (
        <View style={{ backgroundColor: '#000000', flex: 1 }}>
          <Text style={{ color: 'pink', fontSize: 45 }}>Loading</Text>
        </View>
      )
    }

    return (
      <Provider store={store}>
        <View style={styles.container}>
          <Navigator />
          <InitialScreen />
        </View>
      </Provider>
    )
  }
}
```