### PR TITLE
Enable multiple persistReducer calls to work correctly

### DIFF
--- a/src/persistReducer.js
+++ b/src/persistReducer.js
@@ -14,7 +14,7 @@ import getStoredState from './getStoredState'
 import purgeStoredState from './purgeStoredState'
 
 type PersistPartial = { _persist: PersistState }
-/* 
+/*
   @TODO add validation / handling for:
   - persisting a reducer which has nested _persist
   - handling actions that fire before reydrate is called
@@ -113,11 +113,6 @@ export default function persistReducer<State: Object, Action: Object>(
           }
         }
 
-      case PURGE:
-        _purge = true
-        purgeStoredState(config)
-        return state
-
       default:
         // @TODO more performant workaround for combineReducers warning
         let newState = {
@@ -126,6 +121,11 @@ export default function persistReducer<State: Object, Action: Object>(
         }
         _persistoid && _persistoid.update(newState)
         return newState
+
+      case PURGE:
+        _purge = true
+        purgeStoredState(config)
+        return state
     }
   }
 }

--- a/src/persistReducer.js
+++ b/src/persistReducer.js
@@ -113,19 +113,19 @@ export default function persistReducer<State: Object, Action: Object>(
           }
         }
 
-      default:
-        // @TODO more performant workaround for combineReducers warning
-        let newState = {
-          ...baseReducer(restState, action),
-          _persist,
-        }
-        _persistoid && _persistoid.update(newState)
-        return newState
-
       case PURGE:
         _purge = true
         purgeStoredState(config)
         return state
     }
+
+    // @NOTE default pass through reducer if the switch statement above did not return
+    // @TODO more performant workaround for combineReducers warning
+    let newState = {
+      ...baseReducer(restState, action),
+      _persist,
+    }
+    _persistoid && _persistoid.update(newState)
+    return newState
   }
 }


### PR DESCRIPTION
I believe this fixes #412. I was debugging this and observed that on line 99 you state: 

`@NOTE if key does not match, will continue to default case`

This is inside `case REHYDRATE`.  For some reason, this case was falling through after the first REHYDRATE call in some instances, but it doesn't fall through to `default`. Instead it falls through to `PURGE`, which I don't think was the intent. 

If you take the example I gave in the related issue, `combineReducers` maps each action to each reducer. So first `action.key (user) === config.key (user)` but in the second pass, `action.key (user) === config.key (incidents)` and it falls through and set's `_purge` to true. 

Then, when it goes to process the second `REHYDRATE` (`action.key (incidents)`), we never get to line 100 because of `if (_purge) return state`.

So it seems that _purge isn't being reset across `REHYDRATE` actions as well?

So all that to say, I know that this change fixes my use case of wanting to REHYDRATE multiple store nodes, but I'm not sure if this change is the actual final solution or just a first step.