### PR TITLE
fix error where persistReducer function doesn't return any value

### DIFF
--- a/src/persistReducer.js
+++ b/src/persistReducer.js
@@ -112,15 +112,15 @@ export default function persistReducer<State: Object, Action: Object>(
           _persist: { ..._persist, rehydrated: true },
         }
       }
-    } else {
-      // @NOTE default pass through reducer if the switch statement above did not return
-      // @TODO more performant workaround for combineReducers warning
-      let newState = {
-        ...baseReducer(restState, action),
-        _persist,
-      }
-      _persistoid && _persistoid.update(newState)
-      return newState
     }
+
+    // @NOTE default pass through reducer if the switch statement above did not return
+    // @TODO more performant workaround for combineReducers warning
+    let newState = {
+      ...baseReducer(restState, action),
+      _persist,
+    }
+    _persistoid && _persistoid.update(newState)
+    return newState
   }
 }


### PR DESCRIPTION
Just got around to testing, and I found that if the keys don't match, persistReducer doesn't return anything and redux throws an error. 

https://github.com/rt2zz/redux-persist/blob/a4c3695395852ecf20ff186f74c2c598f87fe291/src/persistReducer.js#L95-L124

Removing the `else` and letting it truly fall through fixes it for me. 

Third time's the charm? ;) On the plus side, I'm getting much better at github.. ha.