### PR TITLE
(persistor): remove json-stringify-safe in favor of plain json stringify with try/catch

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,5 @@
   "peerDependencies": {
     "redux": ">3.0.0"
   },
-  "dependencies": {
-    "json-stringify-safe": "^5.0.1"
-  }
+  "dependencies": {}
 }

--- a/src/getStoredState.js
+++ b/src/getStoredState.js
@@ -29,11 +29,11 @@ export default function getStoredState(
     else {
       try {
         let state = {}
-        let rawState = deserializer(serialized)
+        let rawState = deserialize(serialized)
         Object.keys(rawState).forEach(key => {
           state[key] = transforms.reduceRight((subState, transformer) => {
             return transformer.out(subState, key)
-          }, deserializer(rawState[key]))
+          }, deserialize(rawState[key]))
         })
         onComplete(null, state)
       } catch (err) {
@@ -57,6 +57,6 @@ export default function getStoredState(
   }
 }
 
-function deserializer(serial) {
+function deserialize(serial) {
   return JSON.parse(serial)
 }


### PR DESCRIPTION
1. JSON.stringify is super fast
2. stringify-safe would catch cycles, but the resulting state would not be 1-1 with the original making for potential unexpected behavior. Better to just catch and ignore that piece of state.

If implementations specifically require cycle replacement, we can expose serialize as through config in the future. 