### PR TITLE
[types] mark config as optional in persistStore

### DIFF
--- a/type-definitions/index.js.flow
+++ b/type-definitions/index.js.flow
@@ -52,7 +52,7 @@ type AutoRehydrateConfig = {
 declare function createPersistor(store: Store, config: Config): Persistor
 declare function createTransform(in: Transformer, out: Transformer, config?: TransformConfig): Transform
 declare function getStoredState(config: Config, ?StoredStateCallback): ?Promise<Object>
-declare function persistStore(store: Store, config: Config, onComplete?: OnComplete): Persistor
+declare function persistStore(store: Store, config?: Config, onComplete?: OnComplete): Persistor
 declare function purgeStoredState(config: Config, keys?: Array<string>): Promise<void>
 declare function autoRehydrate(config: ?AutoRehydrateConfig): StoreEnhancer
 


### PR DESCRIPTION
According to both the API documentation for `persistStore` and the method definition in the code itself allow for the `config` parameter to be omitted.

This PR modifies the flow type of `persistStore` to align with that expectation.