### PR TITLE
Added unpkg field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "typings": "lib/index.d.ts",
   "module": "es/index.js",
   "jsnext:main": "es/index.js",
+  "unpkg": "dist/redux-persist.min.js",
   "scripts": {
     "test": "standard 'src/**/*.js' 'test/**/*.js' && BABEL_ENV=commonjs ava --esnext",
     "test:watch": "npm test -- --watch",


### PR DESCRIPTION
This will allow nicer unpkg urls.

https://unpkg.com/redux-persist instead of https://unpkg.com/redux-persist/dist/redux-persist.min.js