### PR TITLE
Flush function

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ persistStore(store, config, callback).purge()
       - pauses persistence
     - `resume()`
       - resumes persistence
+    - `flush()`
+      - forces everything to be written to storage. Returns a promise that resolves when everything is stored successfully, rejects on any errors.
 
 #### `autoRehydrate(config)`
   - This is a store enhancer that will automatically shallow merge the persisted state for each key. Additionally it queues any actions that are dispatched before rehydration is complete, and fires them after rehydration is finished.

--- a/src/createPersistor.js
+++ b/src/createPersistor.js
@@ -31,7 +31,9 @@ export default function createPersistor (store, config) {
   let storesToProcess = []
   let timeIterator = null
 
-  store.subscribe(() => {
+  store.subscribe(storeListener)
+
+  function storeListener () {
     if (paused) return
 
     let state = store.getState()
@@ -58,9 +60,12 @@ export default function createPersistor (store, config) {
     }
 
     lastState = state
-  })
+  }
 
   function flush () {
+    // Because redux can batch calling the subscribed listeners in some edge-cases, we need to
+    // make sure our `storesToProcess` array is up to date by calling `storeListener` here.
+    storeListener()
     return Promise.all(storesToProcess.map(persistOneStore))
   }
 

--- a/src/createPersistor.js
+++ b/src/createPersistor.js
@@ -53,14 +53,33 @@ export default function createPersistor (store, config) {
         }
 
         let key = storesToProcess.shift()
-        let storageKey = createStorageKey(key)
-        let endState = transforms.reduce((subState, transformer) => transformer.in(subState, key), stateGetter(store.getState(), key))
-        if (typeof endState !== 'undefined') storage.setItem(storageKey, serializer(endState), warnIfSetError(key))
+        persistOneStore(key)
       }, debounce)
     }
 
     lastState = state
   })
+
+  function flush () {
+    return Promise.all(storesToProcess.map(persistOneStore))
+  }
+
+  function persistOneStore (key) {
+    return new Promise((resolve, reject) => {
+      let storageKey = createStorageKey(key)
+      let endState = transforms.reduce((subState, transformer) => transformer.in(subState, key), stateGetter(store.getState(), key))
+      if (typeof endState !== 'undefined') {
+        storage.setItem(storageKey, serializer(endState), (err) => {
+          if (err && process.env.NODE_ENV !== 'production') { console.warn('Error storing data for key:', key, err) }
+          if (err) {
+            reject(err)
+          } else {
+            resolve()
+          }
+        })
+      }
+    })
+  }
 
   function passWhitelistBlacklist (key) {
     if (whitelist && whitelist.indexOf(key) === -1) return false
@@ -95,15 +114,10 @@ export default function createPersistor (store, config) {
   // return `persistor`
   return {
     rehydrate: adhocRehydrate,
+    flush,
     pause: () => { paused = true },
     resume: () => { paused = false },
     purge: (keys) => purgeStoredState({storage, keyPrefix}, keys)
-  }
-}
-
-function warnIfSetError (key) {
-  return function setError (err) {
-    if (err && process.env.NODE_ENV !== 'production') { console.warn('Error storing data for key:', key, err) }
   }
 }
 


### PR DESCRIPTION
For issue #252 

This adds a `flush` function to the persistor object which when called will force everything currently in the `storesToProcess` to get flushed to the storage engine, and it returns a promise that resolves when completed.

It looks like a bunch of things are different in the "changed files" but most of that is because I had to pull out some inline files into their own defined functions.

I had to pull the function in the `subscribe` call out and call it during the flush because of how Redux handles multiple nested calls to `dispatch` (it doesn't call the subscribed listener until the "root" dispatch call completes).

So if you had multiple nested calls to `dispatch` in your application and one of the deeper ones calls this `flush` function, you may not have had some of the stuff dispatched to the store flushed to the storage engine. Calling `storeListener` in the flush function solves this problem.

Let me know if you want me to change anything or explain my reasoning. I also tried to keep it in your style, and it passes standard.