### PR TITLE
avoid race conditions icw persistor.pause

### DIFF
--- a/src/createPersistor.js
+++ b/src/createPersistor.js
@@ -42,11 +42,12 @@ export default function createPersistor (store, config) {
       if (storesToProcess.indexOf(key) !== -1) return
       storesToProcess.push(key)
     })
-
+    
+    const len = storesToProcess.length
     // time iterator (read: debounce)
     if (timeIterator === null) {
       timeIterator = setInterval(() => {
-        if (storesToProcess.length === 0) {
+        if ((paused && len === storesToProcess.length) || storesToProcess.length === 0) {
           clearInterval(timeIterator)
           timeIterator = null
           return


### PR DESCRIPTION
To avoid race conditions after` persistor.pause()` is called.

Atomicity of the entire operation is still preserved.