### PR TITLE
To avoid race conditions after `persistor.pause()` is called.

### DIFF
--- a/src/createPersistor.js
+++ b/src/createPersistor.js
@@ -43,10 +43,12 @@ export default function createPersistor (store, config) {
       storesToProcess.push(key)
     })
 
+    const len = storesToProcess.length
+
     // time iterator (read: debounce)
     if (timeIterator === null) {
       timeIterator = setInterval(() => {
-        if (storesToProcess.length === 0) {
+        if ((paused && len === storesToProcess.length) || storesToProcess.length === 0) {
           clearInterval(timeIterator)
           timeIterator = null
           return


### PR DESCRIPTION
While keeping the atomicity of the storage operation intact.