### PR TITLE
Rehydrate including reduced state

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-persist",
-  "version": "5.0.0-rc.6",
+  "version": "5.0.0-rc.6.bp.3",
   "description": "persist and rehydrate redux stores",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/src/constants.js
+++ b/src/constants.js
@@ -8,3 +8,5 @@ export const PERSIST = 'persist/PERSIST'
 export const PURGE = 'persist/PURGE'
 export const REGISTER = 'persist/REGISTER'
 export const DEFAULT_VERSION = -1
+export const AUTO_REHYDRATE = 1
+export const AUTO_REHYDRATE_WITH_REDUCED_STATE = 3

--- a/src/persistReducer.js
+++ b/src/persistReducer.js
@@ -132,7 +132,7 @@ export default function persistReducer<State: Object, Action: Object>(
         let reducedState = baseReducer(restState, action)
         let inboundState = action.payload
         let reconciledRest: State =
-          autoRehydrate === false
+            ! autoRehydrate
             ? reducedState
             : stateReconciler(state, inboundState, reducedState, config)
 

--- a/src/stateReconciler.js
+++ b/src/stateReconciler.js
@@ -1,12 +1,13 @@
 // @flow
 
 import type { PersistConfig } from './types'
+import { AUTO_REHYDRATE, AUTO_REHYDRATE_WITH_REDUCED_STATE } from './constants'
 
 export default function stateReconciler<State: Object>(
   originalState: State,
   inboundState: State,
   reducedState: State,
-  { debug }: PersistConfig
+  { debug, autoRehydrate }: PersistConfig
 ): State {
   // various dev only sanity checks
   if (process.env.NODE_ENV !== 'production') {
@@ -67,8 +68,10 @@ export default function stateReconciler<State: Object>(
           )
         return
       }
-      // otherwise hard set the new value
-      newState[key] = inboundState[key]
+      newState[key] = autoRehydrate === AUTO_REHYDRATE_WITH_REDUCED_STATE
+                    ? {...newState[key], ...inboundState[key]}
+                    // otherwise hard set the new value
+                    : inboundState[key]
     })
   }
 

--- a/src/types.js
+++ b/src/types.js
@@ -21,7 +21,7 @@ export type PersistConfig = {
   throttle?: number,
   migrate?: (PersistedState, number) => Promise<PersistedState>,
   getStoredState?: PersistConfig => Promise<PersistedState>,
-  autoRehydrate?: boolean,
+  autoRehydrate?: [boolean | number],
 }
 
 export type PersistorOptions = {


### PR DESCRIPTION
In v4, when auto-rehydrating, the reduced state is enhanced by the incoming state. However, this is no longer the case in v5, if for the given subtree a transform function is provided.

This PR adds a flag that allows previous behaviour.

Happy to add to the docs as well, if PR in general is accepted. In fact, it's more like a RFC.