### PR TITLE
add missing quotation mark symbol to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Standard Usage:
 
 Recommended Additions
 - use new **PersistGate** to delay rendering until rehydration is complete
-  - `import { PersistGate } from 'redux-persist/lib/integration/react`
+  - `import { PersistGate } from 'redux-persist/lib/integration/react'`
 - set `config.debug = true` to get useful logging
 
 If your implementatation uses getStoredState + createPersistor see [alternate migration](./docs/v5-migration-alternate.md)


### PR DESCRIPTION
I've just pasted line from README.md to my editor and seems it lacks closing quote mark. I hope it will save time for others.