### PR TITLE
Add option to opt-out of serializing and deserializing state from storage

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -60,6 +60,7 @@ The Persistor is a redux store unto itself, plus
   keyPrefix?: string, // will be prefixed to the storage key
   debug?: boolean, // true -> verbose logs
   stateReconciler?: boolean | StateReconciler, // false -> do not automatically reconcile state
+  serialize?: boolean, // false -> do not call JSON.parse & stringify when setting & getting from storage
 }
 ```
 
@@ -93,7 +94,7 @@ Where Persistoid is [defined below](#type-persistoid).
 
 ### `type Persistoid`
 ```js
-{ 
+{
   update: (State) => void
 }
 ```

--- a/src/createPersistoid.js
+++ b/src/createPersistoid.js
@@ -13,8 +13,8 @@ export default function createPersistoid(config: PersistConfig): Persistoid {
   const storageKey = `${config.keyPrefix !== undefined
     ? config.keyPrefix
     : KEY_PREFIX}${config.key}`
-
   const storage = config.storage
+  const serialize = config.serialize === false ? x => x : defaultSerialize
 
   // initialize stateful values
   let lastState = {}
@@ -99,6 +99,6 @@ export default function createPersistoid(config: PersistConfig): Persistoid {
 }
 
 // @NOTE in the future this may be exposed via config
-function serialize(data) {
+function defaultSerialize(data) {
   return JSON.stringify(data)
 }

--- a/src/getStoredState.js
+++ b/src/getStoredState.js
@@ -13,7 +13,7 @@ export default function getStoredState(
     : KEY_PREFIX}${config.key}`
   const storage = config.storage
   const debug = config.debug
-
+  const deserialize = config.serialize === false ? x => x : defaultDeserialize
   return storage.getItem(storageKey).then(serialized => {
     if (!serialized) return undefined
     else {
@@ -38,6 +38,6 @@ export default function getStoredState(
   })
 }
 
-function deserialize(serial) {
+function defaultDeserialize(serial) {
   return JSON.parse(serial)
 }

--- a/src/types.js
+++ b/src/types.js
@@ -22,6 +22,7 @@ export type PersistConfig = {
   stateReconciler?: boolean | Function,
   getStoredState?: PersistConfig => Promise<PersistedState>, // used for migrations
   debug?: boolean,
+  serialize?: boolean,
 }
 
 export type PersistorOptions = {


### PR DESCRIPTION
When working with browser extensions the automatic serializing and deserializing with JSON.stringify and JSON.parse before reading & writing to the store can be troublesome.

The [browser.storage.local](https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/storage/local) API for extensions already handles parsing state and returns a native object for `.get` calls. In order to get redux-persist to work with storage.local, in my `storage.setItem` function I had to write code calling JSON.parse to get a native object again before writing to storage. This seems pretty unnecessary to me.