### PR TITLE
(persistCombineReducers): new persistCombineReducers, recommended default for top level persistence

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -59,7 +59,7 @@ The Persistor is a redux store unto itself, plus
   throttle?: number,
   keyPrefix?: string, // will be prefixed to the storage key
   debug?: boolean, // true -> verbose logs
-  stateReconciler?: boolean | StateReconciler, // false -> do not automatically reconcile state
+  stateReconciler?: false | StateReconciler, // false -> do not automatically reconcile state
 }
 ```
 
@@ -109,13 +109,13 @@ Where enhancer will be sent verbatim to the redux createStore call used to creat
 ### `type StateReconciler`
 ```js
 (
-  originalState: State,
   inboundState: State,
+  originalState: State,
   reducedState: State,
 ) => State
 ```
 A function which reconciles:
-- **originalState**: the state before the REHYDRATE action
 - **inboundState**: the state being rehydrated from storage
+- **originalState**: the state before the REHYDRATE action
 - **reducedState**: the store state *after* the REHYDRATE action but *before* the reconcilliation
 into final "rehydrated" state.

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 // @flow
 
 export { default as persistReducer } from './persistReducer'
+export { default as persistCombineReducers } from './persistCombineReducers'
 export { default as persistStore } from './persistStore'
 export { default as createMigrate } from './createMigrate'
 export { default as createTransform } from './createTransform'

--- a/src/persistCombineReducers.js
+++ b/src/persistCombineReducers.js
@@ -1,0 +1,22 @@
+// @flow
+
+import { combineReducers } from 'redux'
+import persistReducer from './persistReducer'
+import autoMergeLevel2 from './stateReconciler/autoMergeLevel2'
+
+import type { PersistConfig } from './types'
+
+type Reducers = {
+  [key: string]: Function,
+}
+
+type Reducer = (state: Object, action: Object) => Object
+
+// combineReudcers + persistReducer with stateReconciler defaulted to autoMergeLevel2
+export default function persistCombineReducers(
+  config: PersistConfig,
+  reducers: Reducers
+): Reducer {
+  config.stateReconciler = config.stateReconciler || autoMergeLevel2
+  return persistReducer(config, combineReducers(reducers))
+}

--- a/src/persistReducer.js
+++ b/src/persistReducer.js
@@ -135,8 +135,8 @@ export default function persistReducer<State: Object, Action: Object>(
         let reducedState = baseReducer(restState, action)
         let inboundState = action.payload
         let reconciledRest: State =
-          typeof stateReconciler === 'function'
-            ? stateReconciler(state, inboundState, reducedState, config)
+          stateReconciler !== false
+            ? stateReconciler(inboundState, state, reducedState, config)
             : reducedState
 
         return {

--- a/src/stateReconciler/autoMergeLevel2.js
+++ b/src/stateReconciler/autoMergeLevel2.js
@@ -1,14 +1,15 @@
 // @flow
 
 /*
-  autoMergeLevel1: 
-    - merges 1 level of substate
+  autoMergeLevel2: 
+    - merges 2 level of substate
     - skips substate if already modified
+    - this is essentially redux-perist v4 behavior
 */
 
 import type { PersistConfig } from '../types'
 
-export default function autoMergeLevel1<State: Object>(
+export default function autoMergeLevel2<State: Object>(
   inboundState: State,
   originalState: State,
   reducedState: State,
@@ -73,8 +74,8 @@ export default function autoMergeLevel1<State: Object>(
           )
         return
       }
-      // otherwise hard set the new value
-      newState[key] = inboundState[key]
+      // otherwise shallow merge the new values (hence "Level2")
+      newState[key] = { ...newState[key], ...inboundState[key] }
     })
   }
 

--- a/src/stateReconciler/hardSet.js
+++ b/src/stateReconciler/hardSet.js
@@ -1,0 +1,10 @@
+// @flow
+
+/*
+  hardSet: 
+    - hard set incoming state
+*/
+
+export default function hardSet<State: Object>(inboundState: State): State {
+  return inboundState
+}

--- a/src/types.js
+++ b/src/types.js
@@ -19,7 +19,7 @@ export type PersistConfig = {
   transforms?: Array<Transform>,
   throttle?: number,
   migrate?: (PersistedState, number) => Promise<PersistedState>,
-  stateReconciler?: boolean | Function,
+  stateReconciler?: false | Function,
   getStoredState?: PersistConfig => Promise<PersistedState>, // used for migrations
   debug?: boolean,
 }

--- a/tests/persistCombineReducers.spec.js
+++ b/tests/persistCombineReducers.spec.js
@@ -1,0 +1,23 @@
+// @flow
+
+import persistCombineReducers from '../src/persistCombineReducers'
+import createWebStorage from '../src/storage/createWebStorage'
+
+import test from 'ava'
+
+const config = {
+  key: 'TestConfig',
+  storage: createWebStorage('local')
+}
+
+test('persistCombineReducers returns a function', t => {
+  let reducer = persistCombineReducers(config, {
+    foo: () => ({})
+  })
+
+  t.is(typeof reducer, 'function')
+})
+
+test.skip('persistCombineReducers merges two levels deep of state', t => {
+  
+})


### PR DESCRIPTION
resolves https://github.com/rt2zz/redux-persist/issues/506

v4 had a convenient behavior where it should shallow merge two levels deep, meaning additions to initialState of a reducer would automatically get included in the reconciled state. We can no longer make this assumption on v5 because persistence can be nested. 

This solves the issue by shipping a new recommended method `persistCombineReducers` which is basically redux combineReducers + setting the default state reconciler to shallow merge 2 levels deep.

In the future this may also allow us to implement some performance improvements related to how we work around the default combineReducers unrecognized state warnings. Additionally this PR adds `hardSet` state reconciler.