### PR TITLE
Configurable combineReducers for e.g. immutable root state

### DIFF
--- a/src/persistCombineReducers.js
+++ b/src/persistCombineReducers.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { combineReducers as baseCombineReducers } from 'redux'
+import { combineReducers } from 'redux'
 import persistReducer from './persistReducer'
 import autoMergeLevel2 from './stateReconciler/autoMergeLevel2'
 
@@ -18,6 +18,6 @@ export default function persistCombineReducers(
   reducers: Reducers
 ): Reducer {
   config.stateReconciler = config.stateReconciler || autoMergeLevel2
-  combineReducers = config.combineReducers || baseCombineReducers;
-  return persistReducer(config, combineReducers(reducers))
+  config.combineReducers = config.combineReducers || combineReducers;
+  return persistReducer(config, config.combineReducers(reducers))
 }

--- a/src/persistCombineReducers.js
+++ b/src/persistCombineReducers.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { combineReducers } from 'redux'
+import { combineReducers as baseCombineReducers } from 'redux'
 import persistReducer from './persistReducer'
 import autoMergeLevel2 from './stateReconciler/autoMergeLevel2'
 
@@ -18,5 +18,6 @@ export default function persistCombineReducers(
   reducers: Reducers
 ): Reducer {
   config.stateReconciler = config.stateReconciler || autoMergeLevel2
+  combineReducers = config.combineReducers || baseCombineReducers;
   return persistReducer(config, combineReducers(reducers))
 }

--- a/src/types.js
+++ b/src/types.js
@@ -20,6 +20,7 @@ export type PersistConfig = {
   throttle?: number,
   migrate?: (PersistedState, number) => Promise<PersistedState>,
   stateReconciler?: false | Function,
+  combineReducers?: false | (reducers) => Function,
   getStoredState?: PersistConfig => Promise<PersistedState>, // used for migrations
   debug?: boolean,
 }


### PR DESCRIPTION
The hardcoded combineReducers in persistCombineReducers prevents usage of e.g. redux-immutable, which makes it possible to use an immutable root state.
With the small changes in this PR one could specify through the config to use combineReducers of e.g. redux-immutable or any other custom combineReducers function.