### PR TITLE
Allow omitting loading property in PersistGate

### DIFF
--- a/src/integration/react.js
+++ b/src/integration/react.js
@@ -6,7 +6,7 @@ import type { Persistor } from '../types'
 type Props = {
   onBeforeLift?: Function,
   children?: Node,
-  loading: Node,
+  loading?: Node,
   persistor: Persistor,
 }
 
@@ -15,6 +15,10 @@ type State = {
 }
 
 export class PersistGate extends PureComponent<Props, State> {
+  static defaultProps = {
+    loading: null
+  }
+  
   state = {
     bootstrapped: false,
   }


### PR DESCRIPTION
When using _localStorage_/ _sessionStorage_ as storage, state loading time is instant, and so there is no need to use component for loading.

Anyway IMHO using this option should be voluntary

workaround is to pass `null` as a value