### PR TITLE
Resort to memoryStorage during tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "flow-copy": "flow-copy-source src es && flow-copy-source src lib",
     "precommit": "lint-staged",
     "prepublishOnly": "npm run clean && npm run build",
-    "test": "BABEL_ENV=commonjs ava"
+    "test": "NODE_ENV=test BABEL_ENV=commonjs ava"
   },
   "lint-staged": {
     "src/**/*.js": [

--- a/src/storage/getStorage.js
+++ b/src/storage/getStorage.js
@@ -2,7 +2,7 @@
 
 import type { Storage } from '../types'
 
-function noop() { }
+function noop() {}
 let noopStorage = {
   getItem: noop,
   setItem: noop,
@@ -23,7 +23,9 @@ function hasStorage(storageType) {
   } catch (e) {
     if (process.env.NODE_ENV !== 'production')
       console.warn(
-        `redux-persist ${storageType} test failed, persistence will be disabled.`
+        `redux-persist ${
+          storageType
+        } test failed, persistence will be disabled.`
       )
     return false
   }
@@ -32,12 +34,12 @@ function hasStorage(storageType) {
 
 export default function getStorage(type: string): Storage {
   const storageType = `${type}Storage`
-  if (process.env.NODE_ENV === 'test') {
-    return noopStorage;
-  }
   if (hasStorage(storageType)) return window[storageType]
   else {
-    if (process.env.NODE_ENV !== 'production') {
+    if (
+      process.env.NODE_ENV !== 'production' &&
+      process.env.NODE_ENV !== 'test'
+    ) {
       console.error(
         `redux-persist failed to create sync storage. falling back to memory storage.`
       )

--- a/src/storage/getStorage.js
+++ b/src/storage/getStorage.js
@@ -1,6 +1,7 @@
 // @flow
 
 import type { Storage } from '../types'
+import createMemoryStorage from '../../tests/utils/memoryStorage'
 
 function noop() {}
 let noopStorage = {
@@ -43,6 +44,8 @@ export default function getStorage(type: string): Storage {
       console.error(
         `redux-persist failed to create sync storage. falling back to memory storage.`
       )
+    } else if (process.env.NODE_ENV === 'test') {
+      return createMemoryStorage()
     }
     return noopStorage
   }

--- a/src/storage/getStorage.js
+++ b/src/storage/getStorage.js
@@ -2,7 +2,7 @@
 
 import type { Storage } from '../types'
 
-function noop() {}
+function noop() { }
 let noopStorage = {
   getItem: noop,
   setItem: noop,
@@ -32,6 +32,9 @@ function hasStorage(storageType) {
 
 export default function getStorage(type: string): Storage {
   const storageType = `${type}Storage`
+  if (process.env.NODE_ENV === 'test') {
+    return noopStorage;
+  }
   if (hasStorage(storageType)) return window[storageType]
   else {
     if (process.env.NODE_ENV !== 'production') {


### PR DESCRIPTION
This PR resorts to mock storage during tests, so that the `redux-persist failed to create sync storage. falling back to memory storage.` error won't occur during tests.