### PR TITLE
fallback to default version in migrations

### DIFF
--- a/src/createMigrate.js
+++ b/src/createMigrate.js
@@ -18,8 +18,8 @@ export default function createMigrate(
         console.log('redux-persist: no inbound state, skipping migration')
       return Promise.resolve(undefined)
     }
-    // this is gauranteed to exist as version gets added before any state is stored
-    let inboundVersion: number = state._persist.version
+
+    let inboundVersion: number = (state._persist && state._persist.version) || DEFAULT_VERSION
     if (inboundVersion === currentVersion) {
       if (process.env.NODE_ENV !== 'production' && debug)
         console.log('redux-persist: versions match, noop migration')


### PR DESCRIPTION
Related issue/comment: https://github.com/rt2zz/redux-persist/issues/434#issuecomment-342530492

# What's changed?

Currently if you try and upgrade from v4 to v5 using https://github.com/rt2zz/redux-persist/tree/b85b56a889ebd4919c9ba11d239a4ae1861e1da6#experimental-v4-to-v5-state-migration and also add a migration, the migration will attempt to run on the v4 state which has no `_persist` version. 

This pr would allow the migration to fall back on the default version in such a scenario.

## Considerations
- I do not believe this would affect the code in any other situation as regularly this won't be executed without having the `_persist.version`.
- Is there a clearer or cleaner way to tie this code specifically to using the v4 migrate. eg. perhaps we can manually add `_persist` in the v4 `getStoredState` so the v4 migration will not affect any other parts of the code?
