### PR TITLE
Expose serialize/deserialize as config options

### DIFF
--- a/src/createPersistoid.js
+++ b/src/createPersistoid.js
@@ -10,9 +10,10 @@ export default function createPersistoid(config: PersistConfig): Persistoid {
   const whitelist: ?Array<string> = config.whitelist || null
   const transforms = config.transforms || []
   const throttle = config.throttle || 0
-  const storageKey = `${config.keyPrefix !== undefined
-    ? config.keyPrefix
-    : KEY_PREFIX}${config.key}`
+  const storageKey = `${
+    config.keyPrefix !== undefined ? config.keyPrefix : KEY_PREFIX
+  }${config.key}`
+  const serialize = getSerialize(config)
 
   const storage = config.storage
 
@@ -105,7 +106,11 @@ export default function createPersistoid(config: PersistConfig): Persistoid {
   }
 }
 
-// @NOTE in the future this may be exposed via config
-function serialize(data) {
-  return JSON.stringify(data)
+function getSerialize(config) {
+  if (config.serialize && typeof config.serialize === 'function') {
+    return config.serialize
+  }
+
+  // default serialize function
+  return JSON.stringify
 }

--- a/src/getStoredState.js
+++ b/src/getStoredState.js
@@ -18,8 +18,6 @@ export default function getStoredState(
   return storage.getItem(storageKey).then(serialized => {
     if (!serialized) return undefined
     else {
-      const deserialize = shouldSerialise ? deserializeJSON : state => state
-
       try {
         let state = {}
         let rawState = deserialize(serialized)

--- a/src/getStoredState.js
+++ b/src/getStoredState.js
@@ -8,15 +8,18 @@ export default function getStoredState(
   config: PersistConfig
 ): Promise<Object | void> {
   const transforms = config.transforms || []
-  const storageKey = `${config.keyPrefix !== undefined
-    ? config.keyPrefix
-    : KEY_PREFIX}${config.key}`
+  const storageKey = `${
+    config.keyPrefix !== undefined ? config.keyPrefix : KEY_PREFIX
+  }${config.key}`
   const storage = config.storage
   const debug = config.debug
+  const deserialize = getDeSerialize(config)
 
   return storage.getItem(storageKey).then(serialized => {
     if (!serialized) return undefined
     else {
+      const deserialize = shouldSerialise ? deserializeJSON : state => state
+
       try {
         let state = {}
         let rawState = deserialize(serialized)
@@ -38,6 +41,11 @@ export default function getStoredState(
   })
 }
 
-function deserialize(serial) {
-  return JSON.parse(serial)
+function getDeSerialize(config) {
+  if (config.deserialize && typeof config.deserialize === 'function') {
+    return config.deserialize
+  }
+
+  // default deserialize function
+  return JSON.parse
 }


### PR DESCRIPTION
Exposing serialize/deserialize allows us to pass an empty function and turn them off effectively.
