### PR TITLE
Marked inbound and outbound parameters on createTransform as optional

### DIFF
--- a/src/createTransform.js
+++ b/src/createTransform.js
@@ -7,9 +7,9 @@ type TransformConfig = {
 
 export default function createTransform(
   // @NOTE inbound: transform state coming from redux on its way to being serialized and stored
-  inbound: Function,
+  inbound: ?Function,
   // @NOTE outbound: transform state coming from storage, on its way to be rehydrated into redux
-  outbound: Function,
+  outbound: ?Function,
   config: TransformConfig = {}
 ) {
   let whitelist = config.whitelist || null


### PR DESCRIPTION
Since line 26 and 27 check whether they are set, it seems logical to me that the parameters should allow null/undefined.