### PR TITLE
stateReconciler false fix for persistCombineReducers

### DIFF
--- a/src/persistCombineReducers.js
+++ b/src/persistCombineReducers.js
@@ -17,6 +17,9 @@ export default function persistCombineReducers(
   config: PersistConfig,
   reducers: Reducers
 ): Reducer {
-  config.stateReconciler = config.stateReconciler || autoMergeLevel2
+  // default to autoMergeLevel2 only if config.stateReconciler is null or undefined
+  // http://www.ecma-international.org/ecma-262/6.0/#sec-abstract-equality-comparison
+  config.stateReconciler =
+    config.stateReconciler == null ? autoMergeLevel2 : config.stateReconciler
   return persistReducer(config, combineReducers(reducers))
 }


### PR DESCRIPTION
Previously when stateReconciler was set to false in the persistConfig as in:
```
const persistConfig = {
  key: 'key',
  stateReconciler: false,
  ...,
};
const rootReducer = persistCombineReducers(persistConfig, reducers);
```
The persistCombineReducers function would default to autoMergeLevel2, this is not the desired or expected behaviour. This pull requests fixes this by allowing a false value for stateReconciler to be passed through the underlying persistReducer function.