### PR TITLE
Add GitHub link to npmjs page

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "persist and rehydrate redux stores",
   "main": "lib/index.js",
   "module": "es/index.js",
+  "repository": "rt2zz/redux-persist",
   "files": [
     "es",
     "src",


### PR DESCRIPTION
Currently missing from the sidebar: https://www.npmjs.com/package/redux-persist