### PR TITLE
Update readme to present HRM pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ class App extends Component {
 Additional Usage Examples:
 1. [Nested Persists](#nested-persists)
 3. Code Splitting [coming soon]
-4. Hot Module Reloading [coming soon]
+4. [Hot Module Replacement](#hot-module-replacement)
 
 ## v5 Breaking Changes
 There are three important breaking changes.
@@ -180,6 +180,70 @@ const fooConfig = {
 let reducer = combineReducer({
   foo: persistReducer(fooConfig, fooReducer)
 })
+```
+
+## Hot Module Replacement
+
+Hot Module Replacement (HRM) is a wonderful feature that is really useful in development environment. This allows you to update the code of your application without reloading the app and resetting the redux state.
+
+You can configure your reducers to be automatically replaced by Webpack HMR on change. With the following setup, if you add or remove a reducer, that reducer will be automatically injected by Hot Reloading if enable in your app.
+
+**app/redux/index.js**
+```js
+import { combineReducers } from 'redux'
+import { persistReducer } from 'redux-persist'
+import ReduxPersistConfig from 'app/config/reduxPersist' // Whatever path
+import configureStore from './configureStore'
+
+/* ------------- Assemble The reducers ------------- */
+export const reducers = combineReducers({
+  nav: require('./reducers/navigation').reducer,
+  user: require('./reducers/user').reducer
+})
+
+export default () => {
+  const storeTools = configureStore(reducers)
+
+  if (module.hot) {
+    module.hot.accept(() => {
+      // This fetch the new state of the above reducers.
+      const nextRootReducer = require('./').reducers
+      storeTools.store.replaceReducer(
+        persistReducer(ReduxPersistConfig, nextRootReducer)
+      )
+    })
+  }
+
+  return storeTools
+}
+```
+
+**app/redux/configureStore.js**
+```js
+import { createStore, applyMiddleware, compose } from 'redux'
+import { persistStore, persistReducer } from 'redux-persist'
+import ReduxPersistConfig from '../config/reduxPersist' // Whatever path
+import ScreenTracking from './middlewares/screenTrackingMiddleware'
+
+// Store factory function
+export default rootReducer => {
+  /* ------------- redux Configuration ------------- */
+
+  const middleware = []
+  const enhancers = []
+
+  const persistedReducers = persistReducer(ReduxPersistConfig, rootReducer)
+
+  /* ------------- Analytics Middleware ------------- */
+
+  middleware.push(ScreenTracking)
+
+  /* ------------- Assemble Middleware ------------- */
+
+  enhancers.push(applyMiddleware(...middleware))
+
+  return { persistor: persistStore(store), store: createStore(persistedReducers, compose(...enhancers)) }
+}
 ```
 
 ## Experimental v4 to v5 State Migration


### PR DESCRIPTION
As I had the issue as seen here https://github.com/rt2zz/redux-persist/issues/601, I guess this was a nice idea to share my setup with the community.

I present my pattern to handle HMR with `redux` and `redux-persist`.

**EDIT** : It should work for most people but those using Immutable structure ('seamless-immutable' in my case) might encounter an issue with the implementation of persistCombineReducers & Immutable structure using this pattern.

For instance I'm trying to use this now because _persist reducer is now passing through the transformers... This is not the cause with combineReducer method. Even though this is not solving my problem.

```js
const immutableTransformerState = {
  out: state => {
    if (state.hasOwnProperty('version') && state.hasOwnProperty('rehydrated')) {
      return state
    }
    return Immutable(state)
  },
  in: raw => {
    if (Immutable.isImmutable(raw)) {
      return raw.asMutable({ deep: true })
    }

    return raw
  }
}
```

I'm still getting some reducer are not Immutable but they should.
It looks like reducer are processed by the transformers but something is destroying my Immutable from transformers and override them with a standard object... any idea ?