### PR TITLE
Avoid creating new state each time, trigger repeat render.

### DIFF
--- a/src/persistReducer.js
+++ b/src/persistReducer.js
@@ -136,13 +136,18 @@ export default function persistReducer<State: Object, Action: Object>(
       }
     }
 
+    const reducedState = baseReducer(restState, action)
+
     // if we have not already handled PERSIST, straight passthrough
-    if (!_persist) return baseReducer(state, action)
+    if (!_persist) return reducedState
+
+    // if we have not already updated state, straight passthrough
+    if (reducedState === state) return reducedState
 
     // otherwise, pull off _persist, run the reducer, and update the persistoid
     // @TODO more performant workaround for combineReducers warning
     let newState = {
-      ...baseReducer(restState, action),
+      ...reducedState,
       _persist,
     }
     // update the persistoid only if we are already rehydrated and are not paused

--- a/src/persistReducer.js
+++ b/src/persistReducer.js
@@ -141,7 +141,7 @@ export default function persistReducer<State: Object, Action: Object>(
 
     // if we have not already updated state, straight passthrough
     const reducedState = baseReducer(restState, action)
-    if (reducedState === state) return reducedState
+    if (reducedState === restState) return state
 
     // otherwise, pull off _persist, run the reducer, and update the persistoid
     // @TODO more performant workaround for combineReducers warning

--- a/src/persistReducer.js
+++ b/src/persistReducer.js
@@ -136,18 +136,17 @@ export default function persistReducer<State: Object, Action: Object>(
       }
     }
 
-    const reducedState = baseReducer(restState, action)
-
     // if we have not already handled PERSIST, straight passthrough
-    if (!_persist) return reducedState
+    if (!_persist) return baseReducer(state, action)
 
     // if we have not already updated state, straight passthrough
+    const reducedState = baseReducer(restState, action)
     if (reducedState === state) return reducedState
 
     // otherwise, pull off _persist, run the reducer, and update the persistoid
     // @TODO more performant workaround for combineReducers warning
     let newState = {
-      ...reducedState,
+      ...baseReducer(restState, action),
       _persist,
     }
     // update the persistoid only if we are already rehydrated and are not paused


### PR DESCRIPTION
if we have not already updated state, straight passthrough.
Avoid creating new state each time, trigger repeat render.


