### PR TITLE
Improve autoMergeLevel2

### DIFF
--- a/src/stateReconciler/autoMergeLevel2.js
+++ b/src/stateReconciler/autoMergeLevel2.js
@@ -35,22 +35,8 @@ export default function autoMergeLevel2<State: Object>(
         Object.keys(inboundState[key]).forEach(prop => {
           // if the newState doesn't have the stored prop, skip it
           if(!newState[key].hasOwnProperty(prop)) return;
-
-          const newPropType = typeof newState[key][prop];
-          const inboundPropType = typeof inboundState[key][prop];
-
-          // if the inboundState has the same Level2 prop and it's the same type then merge it. Otherwise skip it.
-          if(newPropType === inboundPropType) {
-            newState[key][prop] = inboundState[key][prop];
-          } else if (process.env.NODE_ENV !== 'production' && debug)
-            console.log(
-              'redux-persist/stateReconciler: sub state for key `%s` under prop `%s` has mismatching type (`%s` vs `%s`), skipping.',
-              key,
-              prop,
-              newPropType,
-              inboundPropType
-            )
-          }
+          // Copy the new value from the inbound stored state
+          newState[key][prop] = inboundState[key][prop];
         });
         return
       }

--- a/src/stateReconciler/autoMergeLevel2.js
+++ b/src/stateReconciler/autoMergeLevel2.js
@@ -32,7 +32,26 @@ export default function autoMergeLevel2<State: Object>(
       }
       if (isPlainEnoughObject(reducedState[key])) {
         // if object is plain enough shallow merge the new values (hence "Level2")
-        newState[key] = { ...newState[key], ...inboundState[key] }
+        Object.keys(inboundState[key]).forEach(prop => {
+          // if the newState doesn't have the stored prop, skip it
+          if(!newState[key].hasOwnProperty(prop)) return;
+
+          const newPropType = typeof newState[key][prop];
+          const inboundPropType = typeof inboundState[key][prop];
+
+          // if the inboundState has the same Level2 prop and it's the same type then merge it. Otherwise skip it.
+          if(newPropType === inboundPropType) {
+            newState[key][prop] = inboundState[key][prop];
+          } else if (process.env.NODE_ENV !== 'production' && debug)
+            console.log(
+              'redux-persist/stateReconciler: sub state for key `%s` under prop `%s` has mismatching type (`%s` vs `%s`), skipping.',
+              key,
+              prop,
+              newPropType,
+              inboundPropType
+            )
+          }
+        });
         return
       }
       // otherwise hard set


### PR DESCRIPTION
This fixes an issue where the persisted state of a reducer changes shape from the new initialState of that reducer.  The current implementation leaves all keys in place from both versions instead of maintaining the new state shape.  This could result in duplicate data being stored, making it tougher to track down crashes and bugs.

Currently:

```
let inboundState = {
  reducerA: {
    key1: true,
    key2: [1, 2, 3]
  }
}

let reducedState = {
  reducerA: {
    key2: [],
    key3: true
  }
}

// Merged newState
newState = {
  reducerA: {
    key1: true,
    key2: [1, 2, 3],
    key3: true
  }
}
```

It should be:
```
newState = {
  reducerA: {
    key2: [1, 2, 3],
    key3: true
  }
}
```