### PR TITLE
catch migration error when using filestorage on android

### DIFF
--- a/src/integration/getStoredStateMigrateV4.js
+++ b/src/integration/getStoredStateMigrateV4.js
@@ -17,7 +17,10 @@ export default function getStoredState(v4Config: V4Config) {
     return getStoredStateV5(v5Config).then(state => {
       if (state) return state
       else return getStoredStateV4(v4Config)
-    })
+    }).catch(e => {
+      if (process.env.NODE_ENV !== 'production') console.warn(e);
+      return getStoredStateV4(v4Config);
+    });
   }
 }
 


### PR DESCRIPTION
When updating from v4 to v5 I have an issue when I use redux-persist-filesystem-storage on Android.

The framework throw an FileNotFoundError, thats why the getStoredStateV4 function gets never called.

Catch the error and call the getStoredStateV4 work's for me.