### PR TITLE
Implicitly include _persist key in whitelist.

### DIFF
--- a/src/createPersistoid.js
+++ b/src/createPersistoid.js
@@ -79,7 +79,7 @@ export default function createPersistoid(config: PersistConfig): Persistoid {
   }
 
   function passWhitelistBlacklist(key) {
-    if (whitelist && whitelist.indexOf(key) === -1) return false
+    if (whitelist && whitelist.indexOf(key) === -1 && key !== '_persist') return false
     if (blacklist && blacklist.indexOf(key) !== -1) return false
     return true
   }


### PR DESCRIPTION
We should include the _persist key in the whitelist, even if the user didn't explicitly include it. 

I discovered this bug when I noticed that my migration was running every time I Iaunched my app. This PR should fix that issue.