### PR TITLE
fix(typescript): Specify path for typescript definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "5.5.0",
   "description": "persist and rehydrate redux stores",
   "main": "lib/index.js",
+  "types": "src/index.d.ts",
   "module": "es/index.js",
   "repository": "rt2zz/redux-persist",
   "files": [


### PR DESCRIPTION
The typescript definitions weren't being picked up previously. This is because the main file for the package is in the `lib` directory so the editors were looking for an `index.d.ts` file in the `lib` folder. 

This PR specifies the path where the typings are located.