### PR TITLE
Give transformers access to the full, combined reducer state

### DIFF
--- a/src/createPersistoid.js
+++ b/src/createPersistoid.js
@@ -10,9 +10,9 @@ export default function createPersistoid(config: PersistConfig): Persistoid {
   const whitelist: ?Array<string> = config.whitelist || null
   const transforms = config.transforms || []
   const throttle = config.throttle || 0
-  const storageKey = `${config.keyPrefix !== undefined
-    ? config.keyPrefix
-    : KEY_PREFIX}${config.key}`
+  const storageKey = `${
+    config.keyPrefix !== undefined ? config.keyPrefix : KEY_PREFIX
+  }${config.key}`
   const storage = config.storage
   const serialize = config.serialize === false ? x => x : defaultSerialize
 
@@ -50,7 +50,7 @@ export default function createPersistoid(config: PersistConfig): Persistoid {
 
     let key = keysToProcess.shift()
     let endState = transforms.reduce((subState, transformer) => {
-      return transformer.in(subState, key)
+      return transformer.in(subState, key, lastState)
     }, lastState[key])
     if (typeof endState !== 'undefined') stagedWrite(key, endState)
   }
@@ -79,7 +79,8 @@ export default function createPersistoid(config: PersistConfig): Persistoid {
   }
 
   function passWhitelistBlacklist(key) {
-    if (whitelist && whitelist.indexOf(key) === -1 && key !== '_persist') return false
+    if (whitelist && whitelist.indexOf(key) === -1 && key !== '_persist')
+      return false
     if (blacklist && blacklist.indexOf(key) !== -1) return false
     return true
   }

--- a/src/createTransform.js
+++ b/src/createTransform.js
@@ -22,9 +22,13 @@ export default function createTransform(
   }
 
   return {
-    in: (state: Object, key: string) =>
-      !whitelistBlacklistCheck(key) && inbound ? inbound(state, key) : state,
-    out: (state: Object, key: string) =>
-      !whitelistBlacklistCheck(key) && outbound ? outbound(state, key) : state,
+    in: (state: Object, key: string, fullState: Object) =>
+      !whitelistBlacklistCheck(key) && inbound
+        ? inbound(state, key, fullState)
+        : state,
+    out: (state: Object, key: string, fullState: Object) =>
+      !whitelistBlacklistCheck(key) && outbound
+        ? outbound(state, key, fullState)
+        : state,
   }
 }

--- a/src/getStoredState.js
+++ b/src/getStoredState.js
@@ -8,9 +8,9 @@ export default function getStoredState(
   config: PersistConfig
 ): Promise<Object | void> {
   const transforms = config.transforms || []
-  const storageKey = `${config.keyPrefix !== undefined
-    ? config.keyPrefix
-    : KEY_PREFIX}${config.key}`
+  const storageKey = `${
+    config.keyPrefix !== undefined ? config.keyPrefix : KEY_PREFIX
+  }${config.key}`
   const storage = config.storage
   const debug = config.debug
   const deserialize = config.serialize === false ? x => x : defaultDeserialize
@@ -22,7 +22,7 @@ export default function getStoredState(
         let rawState = deserialize(serialized)
         Object.keys(rawState).forEach(key => {
           state[key] = transforms.reduceRight((subState, transformer) => {
-            return transformer.out(subState, key)
+            return transformer.out(subState, key, rawState)
           }, deserialize(rawState[key]))
         })
         return state

--- a/src/types.js
+++ b/src/types.js
@@ -40,8 +40,8 @@ export type MigrationManifest = {
 }
 
 export type Transform = {
-  in: (Object | string, string) => Object,
-  out: (Object | string, string) => Object,
+  in: (Object | string, string, Object | string) => Object,
+  out: (Object | string, string, Object | string) => Object,
   config?: PersistConfig,
 }
 


### PR DESCRIPTION
For example, this is useful if you have a transformer that needs to filter items in one reducer based on values in another reducer.

Let's say we're building a chat app, where we'd like the 100 most recent messages and the sender info shown right when the app starts up (without making a trip to the server). We have a `users` reducer, which is a bunch of user data objects keyed by `userId`. We also have a `messages` reducer, which is an ordered list of message data objects, with a `senderId` property that refers to the `userId` of the sender. We'd like to build a transformer that persists only the top 100 messages in the `messages` reducer, along with all the users in the `user` reducer that correspond to the senders of those 100 messages.

Right now, this isn't possible. When persisting users in the `users` reducer, the transformer isn't able to access the `messages` reducer to figure out which users are senders of the top 100 messages.

With this PR, that transformer can be written as:
```javascript
import _ from "lodash";

const top100MessagesTransform = createTransform(
    (subState, key, fullState) => {
      if (key === "messages") {
        return _.take(subState, 100);
      } else if (key === "users") {
        const messages = _.take(fullState.messages, 100);
        const senderIdSet = _.keyBy(messages, "senderId");
        return _.pickBy(subState, (user, userId) => _.has(senderIdSet, userId));
      } else {
        return subState;
      }
    },
    (state) => state,
    {whitelist: ["messages", "users"]},
);
```