### PR TITLE
(persistStore): add timeout option

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lib"
   ],
   "scripts": {
+    "ava": "BABEL_ENV=commonjs ava",
     "build": "npm run flow-copy && npm run build:commonjs && npm run build:es",
     "build:commonjs": "cross-env BABEL_ENV=commonjs babel src --out-dir lib",
     "build:es": "cross-env BABEL_ENV=es babel src --out-dir es",

--- a/src/types.js
+++ b/src/types.js
@@ -28,6 +28,7 @@ export type PersistConfig = {
 
 export type PersistorOptions = {
   enhancer?: Function,
+  timeout?: number,
 }
 
 export type Storage = {

--- a/tests/complete.spec.js
+++ b/tests/complete.spec.js
@@ -10,6 +10,7 @@ import { combineReducers, createStore } from 'redux'
 import persistReducer from '../src/persistReducer'
 import persistStore from '../src/persistStore'
 import { createMemoryStorage } from 'storage-memory'
+import brokenStorage from './utils/brokenStorage'
 import { PERSIST, REHYDRATE } from '../src/constants'
 import sleep from './utils/sleep'
 
@@ -28,9 +29,39 @@ test('multiple persistReducers work together', t => {
     const rootReducer = combineReducers({ r1, r2 })
     const store = createStore(rootReducer)
     const persistor = persistStore(store, {}, () => {
-      console.log(store.getState(), persistor.getState()) 
       t.is(persistor.getState().bootstrapped, true)
       resolve()      
     })
+  })
+})
+
+test('persistStore undefined timeout never bootstraps with broken storage', t => {
+  return new Promise((resolve, reject) => {
+    let r1 = persistReducer({...config, storage: brokenStorage}, reducer)
+    const rootReducer = combineReducers({ r1 })
+    const store = createStore(rootReducer)
+    const persistor = persistStore(store, { }, () => {
+      reject()     
+    })
+    setTimeout(() => {
+      t.is(persistor.getState().bootstrapped, false)
+      resolve()
+    }, 10)
+  })
+})
+
+
+test('persistStore timeout forces bootstrap', t => {
+  return new Promise((resolve, reject) => {
+    let r1 = persistReducer({...config, storage: brokenStorage}, reducer)
+    const rootReducer = combineReducers({ r1 })
+    const store = createStore(rootReducer)
+    const persistor = persistStore(store, { timeout: 1 }, () => {
+      t.is(persistor.getState().bootstrapped, true)
+      resolve()
+    })
+    setTimeout(() => {
+      reject()
+    }, 10)
   })
 })

--- a/tests/utils/brokenStorage.js
+++ b/tests/utils/brokenStorage.js
@@ -1,0 +1,13 @@
+// @flow
+
+export default {
+  getItem(): Promise<void> {
+      return new Promise((resolve: Function, reject: Function) => {})
+  },
+  setItem(): Promise<void> {
+      return new Promise((resolve: Function, reject: Function) => {})
+  },
+  removeItem(): Promise<void> {
+      return new Promise((resolve: Function, reject: Function) => {})
+  }
+}


### PR DESCRIPTION
if timeout is exceeded, rehydrate will complete with an error. In the past it would simply hang indefinitely. 

timeout is default undefined -> meaning no effect.

questions:
1. this adds ~120 Bytes - is this worth it?
2. should timeout be defaulted to something large but reasonable like 5s?
3. rather than be a part of redux-persist should timeout be a feature of the storage adapter?	