### PR TITLE
Fix 'remoteItem' typo in TypeScript index.d.ts

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -269,7 +269,7 @@ declare module "redux-persist/es/types" {
     export interface Storage {
         getItem(key: string, ...args: any[]): any;
         setItem(key: string, value: any, ...args: any[]): any;
-        remoteItem(key: string, ...args: any[]): any;
+        removeItem(key: string, ...args: any[]): any;
     }
 }
 


### PR DESCRIPTION
This typo will cause type error when using custom storage persist config.