### PR TITLE
feature: make PersistGate take function as a child component

### DIFF
--- a/src/integration/react.js
+++ b/src/integration/react.js
@@ -5,7 +5,7 @@ import type { Persistor } from '../types'
 
 type Props = {
   onBeforeLift?: Function,
-  children?: Node,
+  children?: Node | Function,
   loading?: Node,
   persistor: Persistor,
 }
@@ -51,6 +51,10 @@ export class PersistGate extends PureComponent<Props, State> {
   }
 
   render() {
+    if (typeof this.props.children === 'function') {
+      return this.props.children(this.state.bootstrapped)
+    }
+
     return this.state.bootstrapped ? this.props.children : this.props.loading
   }
 }


### PR DESCRIPTION
Resolves #655 

PersistGate now takes a function as a child component:
```jsx 
<Provider store={store}>
  <PersistGate persistor={persistor}>
    {bootstraped => (
      // custom component 
    )}
  </PersistGate>
</Provider>
```

In case both `loading` prop and children as function are passed, `loading` prop will be ignored.