### PR TITLE
fix: use self when referencing the global scope

### DIFF
--- a/src/integration/getStoredStateMigrateV4.js
+++ b/src/integration/getStoredStateMigrateV4.js
@@ -24,12 +24,12 @@ export default function getStoredState(v4Config: V4Config) {
 const KEY_PREFIX = 'reduxPersist:'
 
 function hasLocalStorage() {
-  if (typeof window !== 'object' || !('localStorage' in window)) {
+  if (typeof self !== 'object' || !('localStorage' in self)) {
     return false
   }
 
   try {
-    let storage = window.localStorage
+    let storage = self.localStorage
     const testKey = `redux-persist localStorage test`
     storage.setItem(testKey, 'test')
     storage.getItem(testKey)
@@ -55,7 +55,7 @@ const noStorage = {
 }
 const createAsyncLocalStorage = () => {
   if (!hasLocalStorage()) return noStorage
-  let localStorage = window.localStorage
+  let localStorage = self.localStorage
   return {
     getAllKeys: function(cb) {
       try {

--- a/src/storage/getStorage.js
+++ b/src/storage/getStorage.js
@@ -10,12 +10,12 @@ let noopStorage = {
 }
 
 function hasStorage(storageType) {
-  if (typeof window !== 'object' || !(storageType in window)) {
+  if (typeof self !== 'object' || !(storageType in self)) {
     return false
   }
 
   try {
-    let storage = window[storageType]
+    let storage = self[storageType]
     const testKey = `redux-persist ${storageType} test`
     storage.setItem(testKey, 'test')
     storage.getItem(testKey)
@@ -32,7 +32,7 @@ function hasStorage(storageType) {
 
 export default function getStorage(type: string): Storage {
   const storageType = `${type}Storage`
-  if (hasStorage(storageType)) return window[storageType]
+  if (hasStorage(storageType)) return self[storageType]
   else {
     if (process.env.NODE_ENV !== 'production') {
       console.error(


### PR DESCRIPTION
Currently you are not able to use `redux-persist` inside of a [Worker](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API). This is due to `window` not being defined in [`WorkerGlobalScope`](https://developer.mozilla.org/en-US/docs/Web/API/WorkerGlobalScope). This PR fixes the compatibility problem by using [`self`](https://developer.mozilla.org/en-US/docs/Web/API/Window/self) instead of `window`.