### PR TITLE
Add persist() and pause() to Typescript definition

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -161,6 +161,8 @@ declare module "redux-persist/es/types" {
      * pending state serialization and immediately write to disk
      */
     export interface Persistor {
+        pause(): void;
+        persist(): void;
         purge(): Promise<any>;
         flush(): Promise<any>;
         dispatch(action: PersistorAction): PersistorAction;


### PR DESCRIPTION
persist and pause function is missing in Persistor in index.d.ts.