### PR TITLE
Fix BaseReducer typescript definition to be redux-compatible

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -342,7 +342,7 @@ declare module "redux-persist/es/persistReducer" {
     import { PersistState, PersistConfig } from "redux-persist/es/types";
     // persistReducer
     export interface PersistPartial { _persist: PersistState }
-    export type BaseReducer<S, A> = (state: S | void, action: A) => S;
+    export type BaseReducer<S, A> = (state: S, action: A) => S;
     /**
      * It provides a way of combining the reducers, replacing redux's @see combineReducers
      * @param config persistence configuration


### PR DESCRIPTION
Current typescript definitions are not compatible with current redux definitions: https://github.com/rt2zz/redux-persist/issues/753

This is how reducer definition looks like in [redux 3.7.2](https://github.com/reactjs/redux/blob/8f60ba321e8ba5fa71d60fa35573c2cdf9c0d852/index.d.ts#L57)

```ts
export type Reducer<S> = (state: S, action: AnyAction) => S;
```

In redux 4.0.0-beta the definition will be changed to one that involves undefined (which is still incompatible with `void` ([link](https://github.com/reactjs/redux/blob/9f250e0828083c15d0b9dd3d283d7f3f9223246c/index.d.ts#L59)):
```ts
export type Reducer<S = any, A extends Action = AnyAction> = (state: S | undefined, action: A) => S;
``` 

I think it is better to stick to current stable version of redux.