### PR TITLE
fix: config.storage error suggesting wrong import

### DIFF
--- a/src/persistReducer.js
+++ b/src/persistReducer.js
@@ -36,7 +36,7 @@ export default function persistReducer<State: Object, Action: Object>(
     if (!config.key) throw new Error('key is required in persistor config')
     if (!config.storage)
       throw new Error(
-        "redux-persist: config.storage is required. Try using one of the provided storage engines `import storageLocal from 'redux-persist/es/storage/local'"
+        "redux-persist: config.storage is required. Try using one of the provided storage engines `import storage from 'redux-persist/lib/storage'`"
       )
   }
 


### PR DESCRIPTION
It seems like this import has changed but the error message points to a non-existing import.