### PR TITLE
Support for downgrade migrations

### DIFF
--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -21,11 +21,31 @@ const migrations = {
   }
 }
 
+// Optional downgradeMigrations
+const downgradeMigrations = {
+  0: (state) => {
+    // Since in version 1 the old state of version 0 was lost,
+    // use the default values for the state
+    const defaultState = getDefaultState()
+    return {
+      ...defaultState,
+      device: state.device   
+    }
+  },
+  -1: (state) => {
+    // migration to intial state version, 
+    // assuming the state structure didn't chnage between -1 and 0
+    return {
+      ...state
+    }
+  }
+}
+
 const persistConfig = {
   key: 'primary',
   version: 1,
   storage,
-  migrate: createMigrate(migrations, { debug: false }),
+  migrate: createMigrate(migrations, downgradeMigrations, { debug: false }),
 }
 
 const finalReducer = persistReducer(persistConfig, reducer)

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -45,7 +45,7 @@ const persistConfig = {
   key: 'primary',
   version: 1,
   storage,
-  migrate: createMigrate(migrations, downgradeMigrations, { debug: false }),
+  migrate: createMigrate(migrations, { debug: false }, downgradeMigrations),
 }
 
 const finalReducer = persistReducer(persistConfig, reducer)

--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -34,7 +34,7 @@ const downgradeMigrations = {
   },
   -1: (state) => {
     // migration to intial state version, 
-    // assuming the state structure didn't chnage between -1 and 0
+    // assuming the state structure didn't change between -1 and 0
     return {
       ...state
     }

--- a/src/createMigrate.js
+++ b/src/createMigrate.js
@@ -6,8 +6,8 @@ import type { PersistedState, MigrationManifest } from './types'
 
 export default function createMigrate(
   migrations: MigrationManifest,
-  downgradeMigrations?: MigrationManifest,
-  config?: { debug: boolean }
+  config?: { debug: boolean },
+  downgradeMigrations?: MigrationManifest
 ) {
   let { debug } = config || {}
   return function(

--- a/src/createMigrate.js
+++ b/src/createMigrate.js
@@ -42,11 +42,13 @@ export default function createMigrate(
         )
         return Promise.resolve(state)
       }
+      // When downgrading we want to sort the migration functions in descending order
       migrationKeys = Object.keys(downgradeMigrations)
         .map(ver => parseInt(ver))
         .filter(key => inboundVersion >= key && key > currentVersion)
         .sort((a, b) => b - a)
     } else {
+      // When upgrading the applying order is instead ascending
       migrationKeys = Object.keys(migrations)
         .map(ver => parseInt(ver))
         .filter(key => currentVersion >= key && key > inboundVersion)

--- a/tests/persistReducer.spec.js
+++ b/tests/persistReducer.spec.js
@@ -7,16 +7,33 @@ import _ from 'lodash'
 import configureStore from 'redux-mock-store'
 
 import persistReducer from '../src/persistReducer'
+import createMigrate from '../src/createMigrate'
 import { createMemoryStorage } from 'storage-memory'
 import { PERSIST, REHYDRATE } from '../src/constants'
+import type { MigrationManifest } from '../src/types'
 import sleep from './utils/sleep'
 
 let mockStore = configureStore([])
 let reducer = () => ({})
+
+const migrations: MigrationManifest = {
+  [0]: (state) => {
+    return {
+      ...state
+    }
+  },
+  [1]: (state) => {
+    return {
+      ...state
+    }
+  }
+}
+
 const config = {
   key: 'persist-reducer-test',
   version: 1,
-  storage: createMemoryStorage()
+  storage: createMemoryStorage(),
+  migrate: createMigrate(migrations)
 }
 
 test('persistedReducer does not automatically set _persist state', t => {


### PR DESCRIPTION
Added support for downgrade migrations with an optional argument

```js
downgradeMigrations?: MigrationManifest
```

in createMigrate.

Should cover:
https://github.com/rt2zz/redux-persist/issues/831