### PR TITLE
Allow custom combine reducers method

### DIFF
--- a/src/persistCombineReducers.js
+++ b/src/persistCombineReducers.js
@@ -15,11 +15,15 @@ type Reducer = (state: Object, action: Object) => Object
 // combineReducers + persistReducer with stateReconciler defaulted to autoMergeLevel2
 export default function persistCombineReducers(
   config: PersistConfig,
-  reducers: Reducers
+  reducers: Reducers,
+  customCombineReducersMethod?: Function
 ): Reducer {
   config.stateReconciler =
     config.stateReconciler === undefined
       ? autoMergeLevel2
       : config.stateReconciler
-  return persistReducer(config, combineReducers(reducers))
+  const combineReducersHandler = (customCombineReducersMethod) ?
+    customCombineReducersMethod :
+    combineReducers;
+  return persistReducer(config, combineReducersHandler(reducers))
 }


### PR DESCRIPTION
## Description

It would be convenient for applications to be able to extend the `combinedReducers` by allowing them to pass a custom `combineReducers` function through the `persistCombineReducers`. This would allow applications that want to specify or restrict the contexts to persist in the redux store.

## Motivation and Context

Allow applications to extend or override the `combinedReducers` function.
