### PR TITLE
Add React v15.3.0+ as a peerDependency 

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,8 @@
     "storage-memory": "0.0.2"
   },
   "peerDependencies": {
-    "redux": ">3.0.0"
+    "redux": ">3.0.0",
+    "react": ">=15.3.0"
   },
   "dependencies": {}
 }


### PR DESCRIPTION
`PersistGate` uses `React.PureComponent`, introduced in [React v15.3.0](https://github.com/facebook/react/releases/tag/v15.3.0). Not having an adequate version will lead to the error:

    Super expression must either be null or a function, not undefined

This is due to `PersistGate` trying to extend `React.PureComponent` which is undefined, see [my SO post](https://stackoverflow.com/a/51317754/5647260). This PR adds React >=v15.3.0 as a peerDep to specify that redux-persist uses React v15.3.0+. Potentially fixes https://github.com/rt2zz/redux-persist/issues/796 and https://github.com/rt2zz/redux-persist/issues/729.