### PR TITLE
Improve Storage Engines section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ The createTransform function takes three parameters.
 3. Config.
 
 ## Storage Engines
-- **localStorage** `import storage from 'redux-persist/lib/storage'`
+- **localStorage** for web or **AsyncStorage** for React Native `import storage from 'redux-persist/lib/storage'`
 - **sessionStorage** `import storageSession from 'redux-persist/lib/storage/session'`
 - **AsyncStorage** react-native `import { AsyncStorage } from 'react-native'`
 - **[localForage](https://github.com/mozilla/localForage)** recommended for web


### PR DESCRIPTION
Add missing information regarding dynamic storage engine selection when using redux-persist/lib/storage.
I added the info that was already available in [code example](https://github.com/rt2zz/redux-persist/blame/208c6b112ead87b3701dfacaae2cdbe78377775a/README.md#L24).