### PR TITLE
Add redux-persist-expire transformer to the list of transformers

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,7 @@ There are several libraries that tackle some of the common implementations for t
 - [filter](https://github.com/edy/redux-persist-transform-filter) - store or load a subset of your state
 - [filter-immutable](https://github.com/actra-development/redux-persist-transform-filter-immutable) - store or load a subset of your state with support for immutablejs
 - [expire](https://github.com/gabceb/redux-persist-transform-expire) - expire a specific subset of your state based on a property
+- [expire-reducer](https://github.com/kamranahmedse/redux-persist-expire) - more flexible alternative to expire transformer above with more options
 
 When the state object gets persisted, it first gets serialized with `JSON.stringify()`. If parts of your state object are not mappable to JSON objects, the serialization process may transform these parts of your state in unexpected ways. For example, the javascript [Set](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set) type does not exist in JSON. When you try to serialize a Set via `JSON.stringify()`, it gets converted to an empty object. Probably not what you want.
 


### PR DESCRIPTION
Firstly, thank you for the awesome work that you have done.

This PR adds the [expire transformer that I created](https://github.com/kamranahmedse/redux-persist-expire) to the list of transformers. 

There is an existing transformer mentioned in the readme but it did not provide the flexibility that I wanted [in one of my projects](http://github.com/kamranahmedse/githunt); so I wrote my custom transformer and then published it as a library for others to use.