### PR TITLE
(docs) Add web extension storage engine link

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,4 +224,5 @@ The createTransform function takes three parameters.
 - **[redux-persist-fs-storage](https://github.com/leethree/redux-persist-fs-storage)** react-native-fs engine
 - **[redux-persist-cookie-storage](https://github.com/abersager/redux-persist-cookie-storage)** Cookie storage engine, works in browser and Node.js, for universal / isomorphic apps
 - **[redux-persist-weapp-storage](https://github.com/cuijiemmx/redux-casa/tree/master/packages/redux-persist-weapp-storage)** Storage engine for wechat mini program, also compatible with wepy
+- **[redux-persist-webextension-storage](https://github.com/ssorallen/redux-persist-webextension-storage)** Storage engine for browser (Chrome, Firefox) web extension storage
 - **custom** any conforming storage api implementing the following methods: `setItem` `getItem` `removeItem`. (**NB**: These methods must support promises)


### PR DESCRIPTION
[redux-persist-webextension-storage][0] is a redux-persist storage
engine for [WebExtension storage][1]. Both Chrome and Firefox implement
the same API, so the engine can be used in both browsers.

I created redux-persist-webextension-storage to use inside [Tab Wrangler][2], and it's currently used in the production version to wrap Chrome/Firefox web extension local storage.

[0]: https://github.com/ssorallen/redux-persist-webextension-storage
[1]: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/storage
[2]: https://github.com/tabwrangler/tabwrangler