### PR TITLE
(persistoid): Do no unnecessary writes with undefined values

### DIFF
--- a/src/createPersistoid.js
+++ b/src/createPersistoid.js
@@ -37,7 +37,7 @@ export default function createPersistoid(config: PersistConfig): Persistoid {
     //if any key is missing in the new state which was present in the lastState,
     //add it for processing too
     Object.keys(lastState).forEach(key => {
-      if (state[key] === undefined) {
+      if (lastState[key] !== undefined && state[key] === undefined) {
         keysToProcess.push(key)
       }
     })

--- a/tests/createPersistor.spec.js
+++ b/tests/createPersistor.spec.js
@@ -1,0 +1,61 @@
+// @flow
+
+import test from 'ava'
+import sinon from 'sinon'
+import { createMemoryStorage } from 'storage-memory'
+
+import createPersistoid from '../src/createPersistoid'
+const memoryStorage = createMemoryStorage()
+
+const config = {
+  key: 'persist-reducer-test',
+  version: 1,
+  storage: memoryStorage,
+  debug: true
+}
+
+let spy;
+let clock;
+
+test.beforeEach(() => {
+    spy = sinon.spy(memoryStorage, 'setItem')
+    clock = sinon.useFakeTimers()
+});
+
+test.afterEach(() => {
+    spy.restore()
+    clock.restore()
+});
+
+test('it updates changed state', t => {
+    const { update } = createPersistoid(config)
+    update({ a: 1 })
+    clock.tick(1);
+    update({ a: 2 })
+    clock.tick(1);
+    t.true(spy.calledTwice);
+    t.true(spy.withArgs('persist:persist-reducer-test', '{"a":"1"}').calledOnce);
+    t.true(spy.withArgs('persist:persist-reducer-test', '{"a":"2"}').calledOnce);
+})
+
+test('it does not update unchanged state', t => {
+    const { update } = createPersistoid(config)
+    update({ a: undefined, b: 1 })
+    clock.tick(1);
+    // This update should not cause a write.
+    update({ a: undefined, b: 1 })
+    clock.tick(1);
+    t.true(spy.calledOnce);
+    t.true(spy.withArgs('persist:persist-reducer-test', '{"b":"1"}').calledOnce);
+})
+
+test('it updates removed keys', t => {
+    const { update } = createPersistoid(config)
+    update({ a: undefined, b: 1 })
+    clock.tick(1);
+    update({ a: undefined, b: undefined })
+    clock.tick(1);
+    t.true(spy.calledTwice);
+    t.true(spy.withArgs('persist:persist-reducer-test', '{"b":"1"}').calledOnce);
+    t.true(spy.withArgs('persist:persist-reducer-test', '{}').calledOnce);
+})


### PR DESCRIPTION
Earlier, unchanged undefined values caused unnecessary writes.

These changes also introduce unit tests for `Persistoid.update`.