### PR TITLE
Misleading error message when initializing redux-persist server side.

### DIFF
--- a/src/storage/getStorage.js
+++ b/src/storage/getStorage.js
@@ -36,7 +36,7 @@ export default function getStorage(type: string): Storage {
   else {
     if (process.env.NODE_ENV !== 'production') {
       console.error(
-        `redux-persist failed to create sync storage. falling back to memory storage.`
+        `redux-persist failed to create sync storage. falling back to noop storage.`
       )
     }
     return noopStorage


### PR DESCRIPTION
Memory storage is usually considered as something different than actually not storing it at all. I feel like renaming it to noop storage fits better.