### PR TITLE
(persistReducer) Fix frozen _persist bug

### DIFF
--- a/src/persistReducer.js
+++ b/src/persistReducer.js
@@ -188,7 +188,10 @@ export default function persistReducer<State: Object, Action: Object>(
     let newState = baseReducer(restState, action)
     if (newState === restState) return state
     else {
-      newState._persist = _persist
+      newState = {
+        ...newState,
+        _persist,
+      }
       return conditionalUpdate(newState)
     }
   }


### PR DESCRIPTION
Related with problems when using immutable or any other state manager that freezes the object which includes `_persist` object. This pull request addresses the issue.

Related: https://github.com/rt2zz/redux-persist/issues/913