### PR TITLE
Stop process blacklisted and already pushed keys from lastState

### DIFF
--- a/src/createPersistoid.js
+++ b/src/createPersistoid.js
@@ -37,7 +37,11 @@ export default function createPersistoid(config: PersistConfig): Persistoid {
     //if any key is missing in the new state which was present in the lastState,
     //add it for processing too
     Object.keys(lastState).forEach(key => {
-      if (state[key] === undefined) {
+      if (
+        state[key] === undefined &&
+        passWhitelistBlacklist(key) &&
+        keysToProcess.indexOf(key) === -1
+      ) {
         keysToProcess.push(key)
       }
     })


### PR DESCRIPTION
Fixes the issue with processing blacklisted keys in redux-persist@5.10.0 caused by #813.