### PR TITLE
Add configurable handler to onWriteFail

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -63,8 +63,12 @@ The Persistor is a redux store unto itself, plus
   debug?: boolean, // true -> verbose logs
   stateReconciler?: false | StateReconciler, // false -> do not automatically reconcile state
   serialize?: boolean, // false -> do not call JSON.parse & stringify when setting & getting from storage
+  writeFailHandler?: Function, // will be called if the storage engine fails during setItem()
 }
 ```
+
+Persisting state involves calling setItem() on the storage engine. By default, this will fail silently if the storage/quota is exhausted.  
+Provide a writeFailHandler(error) function to be notified if this occurs.
 
 ### `type MigrationManifest`
 ```js

--- a/src/createPersistoid.js
+++ b/src/createPersistoid.js
@@ -17,6 +17,7 @@ export default function createPersistoid(config: PersistConfig): Persistoid {
   }${config.key}`
   const storage = config.storage
   const serialize = config.serialize === false ? x => x : defaultSerialize
+  const writeFailHandler = config.writeFailHandler || null
 
   // initialize stateful values
   let lastState = {}
@@ -107,6 +108,7 @@ export default function createPersistoid(config: PersistConfig): Persistoid {
 
   function onWriteFail(err) {
     // @TODO add fail handlers (typically storage full)
+    if (writeFailHandler) writeFailHandler(err)
     if (err && process.env.NODE_ENV !== 'production') {
       console.error('Error storing data', err)
     }

--- a/src/types.js
+++ b/src/types.js
@@ -25,6 +25,7 @@ export type PersistConfig = {
   debug?: boolean,
   serialize?: boolean,
   timeout?: number,
+  writeFailHandler?: Function,
 }
 
 export type PersistorOptions = {


### PR DESCRIPTION
When the storage engine fails to persist data, the exception from setItem() is by default silently ignored. This can happen when storage is full, for example when a browser refuses to allocate enough storage due to the quota being exceeded. (In Chrome, the quota is variable based on a percentage of current free disk space.)

This PR adds an optional function to PersistConfig that will be notified when this happens, which enables the application to deal with it or notify the user.
