### PR TITLE
Add CHANGELOG so that any contributor can add to release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- [PR #949](https://github.com/rt2zz/redux-persist/pull/949) **Allow onWriteFail
+to be passed in config.** The value should be a function to be called in the
+case a write fails (i.e. because the disk it out of space).
+- **Add Community section to README.** Add link to Reactiflux #redux-persist
+channel. Add blog articles about redux-persist from the community.
+
+## 0.2.0 through 5.10.0 - 2015-07-24 through 2018-06-05
+See notes on [GitHub releases page](https://github.com/rt2zz/redux-persist/releases)
+
+[Unreleased]: https://github.com/olivierlacan/keep-a-changelog/compare/v5.10.0...HEAD
+[0.2.0 through 5.10.0]: See notes on [GitHub releases page](https://github.com/rt2zz/redux-persist/releases)


### PR DESCRIPTION
I've really liked using https://keepachangelog.com/en/1.0.0/ in the past. This project has kept a summary of changes on the project's GitHub [releases page](https://github.com/rt2zz/redux-persist/releases), but I think having a CHANGELOG as Markdown encourages anybody to add details of a change, including smaller changes from the broader community.

This also gives the maintainers a way to ask changes to be documented better. I.e. a maintainer can say "this looks good, can you also add a 1-2 sentence summary of the change to CHANGELOG.md?"