### PR TITLE
Fix HMR example

### DIFF
--- a/docs/hot-module-replacement.md
+++ b/docs/hot-module-replacement.md
@@ -7,14 +7,15 @@ The key modification for using HMR with redux-persist, is the incoming hot reduc
 **configureStore.js**
 ```js
 import { persistReducer } from 'redux-persist'
+import rootReducer from './path/to/reducer'
 
 export default () => {
   // create store and persistor per normal...
 
   if (module.hot) {
-    module.hot.accept(() => {
+    module.hot.accept('./path/to/reducer', () => {
       // This fetch the new state of the above reducers.
-      const nextRootReducer = require('./path/to/reducer')
+      const nextRootReducer = require('./path/to/reducer').default
       store.replaceReducer(
         persistReducer(persistConfig, nextRootReducer)
       )


### PR DESCRIPTION
The existing HRM example contains an error, in that webpack's `module.hot.accept()` function doesn't invoke the passed callback on success when the dependencies argument is omitted (it's only invoked on errors).

See: https://webpack.js.org/api/hot-module-replacement/#accept-self-

I've also changed the import line for `nextRootReducer` to explicitly reference the default export, since this file is written in ES modules syntax, and therefore it stands to reason that './path/to/reducer' is also using ES modules syntax.