### PR TITLE
[Bugfix] Issue with immutable state object (and redux-starter-kit)

### DIFF
--- a/src/persistReducer.js
+++ b/src/persistReducer.js
@@ -187,9 +187,6 @@ export default function persistReducer<State: Object, Action: Object>(
     // is state modified ? return original : return updated
     let newState = baseReducer(restState, action)
     if (newState === restState) return state
-    else {
-      newState._persist = _persist
-      return conditionalUpdate(newState)
-    }
+    return conditionalUpdate({ ...newState, _persist })
   }
 }


### PR DESCRIPTION
This fixes an issue with immutable libraries which ensures that the state object is not changeable. For example a reducer which was created with [immer](https://github.com/mweststrate/immer) crashs because the state object was readonly.

immer was part of the (official but WIP) [redux-starter-kit](https://github.com/reduxjs/redux-starter-kit) which I just tested in combination with redux-persist.

In all other cases, the newState object was also extended by creating a new object instead of changing the old one.

Snippet:

```
// import { createSlice } from 'redux-starter-kit'
const MySlice = createSlice({
  slice: 'MySlice',
  initialState = {},
  reducers: {
    testAction: state => {
      state.calledAt = new Date()
    },
  },
})

const reducer = persistReducer({ key: MySlice.slice }, MySlice.reducer)

// ...createStore...

store.dispatch(MySlice.actions.testAction())
```