### PR TITLE
Add correct PersistGate defaultProps to support newer flow versions 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- [PR #974](https://github.com/rt2zz/redux-persist/pull/974) **Add correct PersistGate defaultProps to support newer flow versions.** Adds `children` to defaultProps in `PersistGate` component and removes the optional (`?`) flag in order to be compatible with flow type checking (more explanation can be found in [this flow issue](facebook/flow#1660)). Fixes [#953](https://github.com/rt2zz/redux-persist/issues/953)
 - [PR #949](https://github.com/rt2zz/redux-persist/pull/949) **Allow onWriteFail
 to be passed in config.** The value should be a function to be called in the
 case a write fails (i.e. because the disk it out of space).

--- a/src/integration/react.js
+++ b/src/integration/react.js
@@ -5,8 +5,8 @@ import type { Persistor } from '../types'
 
 type Props = {
   onBeforeLift?: Function,
-  children?: Node | Function,
-  loading?: Node,
+  children: Node | Function,
+  loading: Node,
   persistor: Persistor,
 }
 
@@ -16,6 +16,7 @@ type State = {
 
 export class PersistGate extends PureComponent<Props, State> {
   static defaultProps = {
+    children: null,
     loading: null,
   }
 


### PR DESCRIPTION
As mentioned in #953 there are type errors with some flow versions in the PersistGate component.

The problem with flow is described here:
https://github.com/facebook/flow/issues/1660

A possible solution is described [later in the issue](https://github.com/facebook/flow/issues/1660#issuecomment-386619834) and was already proposed by the creator of issue #953.

So what I did is adding `children: null` to the defaultProps and making `loading and children` not optional anymore. 