### PR TITLE
Checks children and loading props

### DIFF
--- a/src/integration/react.js
+++ b/src/integration/react.js
@@ -51,16 +51,27 @@ export class PersistGate extends PureComponent<Props, State> {
   }
 
   render() {
+    const { children, loading } = this.props
+
     if (process.env.NODE_ENV !== 'production') {
-      if (typeof this.props.children === 'function' && this.props.loading)
+      if (typeof children === 'function' && loading)
         console.error(
           'redux-persist: PersistGate expects either a function child or loading prop, but not both. The loading prop will be ignored.'
         )
     }
-    if (typeof this.props.children === 'function') {
-      return this.props.children(this.state.bootstrapped)
+    if (typeof children === 'function') {
+      return children(this.state.bootstrapped)
     }
 
-    return this.state.bootstrapped ? this.props.children : this.props.loading
+    if (this.state.bootstrapped) {
+      if (children) {
+        return children
+      }
+      return null
+    } else if (loading) {
+      return loading
+    } else {
+      return null
+    }
   }
 }


### PR DESCRIPTION
### What does this PR do?
  Fixes the flow type issue with optional `children` and `loading`.

### Related conversation:
- This is the issue #953 
- This PR has some conversation comments as well https://github.com/rt2zz/redux-persist/pull/974

### Description:
Before the PR changes, the return line was causing problems, since both props are optional `children` and `loading`, doing `return condition ? this.props.children : this.props.loading` is causing Flow to complain, the idea is to set those properties a default value, since `this.props` can't actually be set in the component code, a separate variables should be created that can be set the default values.

The same behavior is done but returning null instead of setting the default value which is null.

### Important comment:
Setting both properties to required and setting default values for them is actually not a semantic solution, documentation is going to show that they are required while they aren't, thus they have to stay optional and the initialization has to be done explicitly somewhere else, because it doesn't make sense to initialize this.props at least to me, should Facebook address that in their Flow implementation?