### PR TITLE
Promise migrate step

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -73,7 +73,7 @@ Provide a writeFailHandler(error) function to be notified if this occurs.
 ### `type MigrationManifest`
 ```js
 {
-  [number]: (State) => State
+  [number]: ((State) => State) | ((State) => Promise<State>)
 }
 ```
 Where the keys are state version numbers and the values are migration functions to modify state.

--- a/src/createMigrate.js
+++ b/src/createMigrate.js
@@ -42,15 +42,17 @@ export default function createMigrate(
     if (process.env.NODE_ENV !== 'production' && debug)
       console.log('redux-persist: migrationKeys', migrationKeys)
     try {
-      let migratedState = migrationKeys.reduce((state, versionKey) => {
-        if (process.env.NODE_ENV !== 'production' && debug)
-          console.log(
-            'redux-persist: running migration for versionKey',
-            versionKey
-          )
-        return migrations[versionKey](state)
-      }, state)
-      return Promise.resolve(migratedState)
+      let migratedStatePromise = migrationKeys.reduce((statePromiseChain, versionKey) => {
+        return statePromiseChain.then(state => {
+          if (process.env.NODE_ENV !== 'production' && debug)
+            console.log(
+              'redux-persist: running migration for versionKey',
+              versionKey
+            )
+          return migrations[versionKey](state)
+        })
+      }, Promise.resolve(state))
+      return Promise.resolve(migratedStatePromise)
     } catch (err) {
       return Promise.reject(err)
     }

--- a/src/types.js
+++ b/src/types.js
@@ -39,7 +39,9 @@ export type Storage = {
 }
 
 export type MigrationManifest = {
-  [number | string]: (PersistedState) => PersistedState,
+  [number | string]:
+    | ((PersistedState) => PersistedState)
+    | ((PersistedState) => Promise<PersistedState>),
 }
 
 export type Transform = {

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -73,7 +73,9 @@ declare module "redux-persist/es/types" {
   }
 
   interface MigrationManifest {
-    [key: string]: (state: PersistedState) => PersistedState;
+    [key: string]:
+      | ((state: PersistedState) => PersistedState)
+      | ((state: PersistedState) => Promise<PersistedState>);
   }
 
   /**


### PR DESCRIPTION
This PR enables each migration step function (as defined in the migration manifest through `createMigrate(manifest)`) to return either the state, or the state wrapped in Promise. Please find the previous discussion in wildlifela/redux-persist-migrate#13.