### PR TITLE
Add an option to delay the automatic persistence.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ const App = () => {
   - arguments
     - **store** *redux store* The store to be persisted.
     - **config** *object* (typically null)
+      - If you want to avoid that the persistence starts immediatly after calling `persistStore`, set the option manualPersist. Example: `{ manualPersist: true }` Persistence can than be started at any point with `peristor.persist()`. You usually want to do this, if your storage is not ready when the `persisStore` call is made.
     - **callback** *function* will be called after rehydration is finished.
   - returns **persistor** object
 

--- a/src/persistStore.js
+++ b/src/persistStore.js
@@ -66,7 +66,7 @@ export default function persistStore(
   let _pStore = createStore(
     persistorReducer,
     initialState,
-    options ? options.enhancer : undefined
+    options && options.enhancer ? options.enhancer : undefined
   )
   let register = (key: string) => {
     _pStore.dispatch({
@@ -123,7 +123,9 @@ export default function persistStore(
     },
   }
 
-  persistor.persist()
+  if (!(options && options.manualPersist)){
+    persistor.persist()
+  }
 
   return persistor
 }

--- a/src/types.js
+++ b/src/types.js
@@ -31,6 +31,7 @@ export type PersistConfig = {
 
 export type PersistorOptions = {
   enhancer?: Function,
+  manualPersist?: boolean
 }
 
 export type Storage = {


### PR DESCRIPTION
There are use cases, where the persistence cannot be started immediately. For example, if there is a passphrase from the user needed, to complete the initialization of the storage.

This PR adds the option `manualPersist`, which if set to true, avoids that the persistence is started automatically. `persistor.persist()` can be called later, to start persistence. For example if the initialization of the storage is completed.

The option is optional, therefore there wont be any compatibility issues, with previous versions. If the options object or the property is not set, everything will behave as before.

This fixes #952 