### PR TITLE
Persist Store Callback

### DIFF
--- a/src/persistStore.js
+++ b/src/persistStore.js
@@ -86,7 +86,7 @@ export default function persistStore(
     store.dispatch(rehydrateAction)
     _pStore.dispatch(rehydrateAction)
     if (boostrappedCb && persistor.getState().bootstrapped) {
-      boostrappedCb()
+      boostrappedCb(store)
       boostrappedCb = false
     }
   }


### PR DESCRIPTION
When the store is persisted, a consumer would need to dispatch an action in his own app, he would therefore need a reference to the store he just persisted. This can be achieved simply passing it through the persist store callback.

Implementation example :
persistStore(store,[null, store => store.dispatch({type:"PERSONAL_ACTION"})]);