### PR TITLE
Remove useBuiltIns from babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,7 +3,6 @@
   "presets": [
     "@babel/preset-flow",
     ["@babel/preset-env", {
-      "useBuiltIns": "usage",
       "modules": false,
       "targets": {
         "browsers": ["last 2 versions"]


### PR DESCRIPTION
Fixes issue with `6.0.0-pre1` where every app using this library must manually add a dependency on `core-js@2`.