### PR TITLE
export DEFAULT_TIMEOUT so it can be consumed from outside

### DIFF
--- a/src/persistReducer.js
+++ b/src/persistReducer.js
@@ -21,7 +21,7 @@ import defaultGetStoredState from './getStoredState'
 import purgeStoredState from './purgeStoredState'
 
 type PersistPartial = { _persist: PersistState }
-const DEFAULT_TIMEOUT = 5000
+export const DEFAULT_TIMEOUT = 5000
 /*
   @TODO add validation / handling for:
   - persisting a reducer which has nested _persist


### PR DESCRIPTION
I wanted to set the default if I'm not in dev mode and I couldn't explicitly do it.