### PR TITLE
Adding write fail handler to typescript definition

### DIFF
--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -44,6 +44,7 @@ declare module "redux-persist/es/types" {
     debug?: boolean;
     serialize?: boolean;
     timeout?: number;
+    writeFailHandler?: (err: Error) => void;
   }
 
   interface PersistorOptions {


### PR DESCRIPTION
Just adding the TypeScript definition for the new `writeFailHandler` in the persist config.