### PR TITLE
Fallback with getStoredStateV4 when getStoredStateV5 promise is rejected

### DIFF
--- a/src/integration/getStoredStateMigrateV4.js
+++ b/src/integration/getStoredStateMigrateV4.js
@@ -18,7 +18,7 @@ export default function getStoredState(v4Config: V4Config) {
     return getStoredStateV5(v5Config).then(state => {
       if (state) return state
       else return getStoredStateV4(v4Config)
-    })
+    }).catch(() => getStoredStateV4(v4Config))
   }
 }
 


### PR DESCRIPTION
We're using [redux-persist-filesystem-storage](https://github.com/robwalkerco/redux-persist-filesystem-storage) as storage provider for our React Native project and we've been trying to upgrade for a while, however we weren't able to migrate our state from v4 to v5 so far. I finally took some time to investigate why the state migration was not working and it turns out something throws inside `getStoredStateV5`.

This happens only first time if the key of the new store doesn't exist yet. As the promise rejection is not handled, and the next run the new store will exist, it is never populated with the old state from the v4 store. Anyway, here's the fix!