### PR TITLE
type-safe persistStore()

### DIFF
--- a/types/persistStore.d.ts
+++ b/types/persistStore.d.ts
@@ -1,5 +1,5 @@
 declare module "redux-persist/es/persistStore" {
-  import { Store } from 'redux';
+  import { Store, Action, AnyAction } from 'redux';
   import { PersistorOptions, Persistor } from "redux-persist/es/types";
 
   /**
@@ -9,7 +9,7 @@ declare module "redux-persist/es/persistStore" {
    * @param callback bootstrap callback of sort.
    */
   // tslint:disable-next-line: strict-export-declare-modifiers
-  export default function persistStore(store: Store, persistorOptions?: PersistorOptions | null, callback?: () => any): Persistor;
+  export default function persistStore<S = any, A extends Action<any> = AnyAction>(store: Store<S, A>, persistorOptions?: PersistorOptions | null, callback?: () => any): Persistor;
 }
 
 declare module "redux-persist/lib/persistStore" {


### PR DESCRIPTION
After this patch, we can `persistStore(store)` without any type errors when using `store: Store<RootState, RootAction>`.

Here is my usage scenario:

```typescript
import React, { StatelessComponent } from "react";
import { Provider } from "react-redux";
import { Route } from "react-router-dom";
import { Store } from "redux";
import { persistStore } from "redux-persist";
import { PersistGate } from "redux-persist/integration/react";

import { Router } from "./Router";
import { RootState, RootAction } from "./store";

interface Props {
  store: Store<RootState, RootAction>;
  app: StatelessComponent;
}

export const Root: StatelessComponent<Props> = ({ store, app }) => (
  <Provider store={store}>
    <PersistGate persistor={persistStore(store)}>
      <Router>
        <Route path="/:path?" component={app} />
      </Router>
    </PersistGate>
  </Provider>
);
```