### PR TITLE
chore: add missing type for persist config

### DIFF
--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -42,7 +42,8 @@ declare module "redux-persist/es/types" {
      */
     getStoredState?: (config: PersistConfig<S, RS, HSS, ESS>) => Promise<PersistedState>;
     debug?: boolean;
-    serialize?: boolean;
+    serialize?: boolean | (data: any) => any;
+    deseriazlize?: boolean | (serialized: any) => any;
     timeout?: number;
     writeFailHandler?: (err: Error) => void;
   }


### PR DESCRIPTION
This PR addresses #1092 
Added deserialize type definition and added function for serialize type