### PR TITLE
chore: add missing type for persist options

### DIFF
--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -49,6 +49,7 @@ declare module "redux-persist/es/types" {
 
   interface PersistorOptions {
     enhancer?: StoreEnhancer<any>;
+    manualPersist?: boolean;
   }
 
   interface Storage {


### PR DESCRIPTION
Added manualPersist type definition to PersistOptions type.
This addresses the issue that TypeScript couldn't infer manualPersist type in PersistOption type, which is only in `src/types.js`.