### PR TITLE
feat(types): improve types for whitelist and blacklist

### DIFF
--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -31,8 +31,8 @@ declare module "redux-persist/es/types" {
      * @deprecated keyPrefix is going to be removed in v6.
      */
     keyPrefix?: string;
-    blacklist?: Array<string>;
-    whitelist?: Array<string>;
+    blacklist?: Array<keyof S>;
+    whitelist?: Array<keyof S>;
     transforms?: Array<Transform<HSS, ESS, S, RS>>;
     throttle?: number;
     migrate?: PersistMigrate;


### PR DESCRIPTION
Any reason this can't be done (i.e. due to keyPrefix)?
If it doesn't play well with keyPrefix, then please ignore this