### PR TITLE
Make '_persist' key optional in state returned by persistReducer

### DIFF
--- a/src/persistReducer.js
+++ b/src/persistReducer.js
@@ -20,7 +20,7 @@ import createPersistoid from './createPersistoid'
 import defaultGetStoredState from './getStoredState'
 import purgeStoredState from './purgeStoredState'
 
-type PersistPartial = { _persist: PersistState }
+type PersistPartial = { _persist?: PersistState }
 const DEFAULT_TIMEOUT = 5000
 /*
   @TODO add validation / handling for:
@@ -73,9 +73,7 @@ export default function persistReducer<State: Object, Action: Object>(
         // dev warning if we are already sealed
         if (process.env.NODE_ENV !== 'production' && _sealed)
           console.error(
-            `redux-persist: rehydrate for "${
-              config.key
-            }" called after timeout.`,
+            `redux-persist: rehydrate for "${config.key}" called after timeout.`,
             payload,
             err
           )
@@ -92,9 +90,7 @@ export default function persistReducer<State: Object, Action: Object>(
             _rehydrate(
               undefined,
               new Error(
-                `redux-persist: persist timed out for persist key "${
-                  config.key
-                }"`
+                `redux-persist: persist timed out for persist key "${config.key}"`
               )
             )
         }, timeout)
@@ -112,7 +108,7 @@ export default function persistReducer<State: Object, Action: Object>(
         return {
           ...baseReducer(restState, action),
           _persist,
-        };
+        }
       }
 
       if (

--- a/types/persistReducer.d.ts
+++ b/types/persistReducer.d.ts
@@ -3,7 +3,7 @@ declare module "redux-persist/es/persistReducer" {
   import { PersistState, PersistConfig } from "redux-persist/es/types";
 
   interface PersistPartial {
-    _persist: PersistState;
+    _persist?: PersistState;
   }
 
   /**


### PR DESCRIPTION
## Issue
At the moment, the `_persist` key in the state returned by the `persistReducer` is mandatory.
This causes issues when using a preloaded state in `redux.createStore`,  which does not have a `_persist` key (eg. when trying to create a store in the browser from a server side rendered store).

```ts
import { createStore } from 'redux'
import { persistReducer } from 'redux-persist';

const rootReducer = persistReducer(config, reducer);
const preloadedState = {};

createStore(
  rootReducer,
  preloadedState // TS Error: Property '_persist' is missing in type {} but required in type '{ _persist: { version: number; rehydrated: boolean; }; }'.ts(2769)
);
```

## Changes
- Makes `_persist` key in state returned by `persistReducer` optional
  - Fixes https://github.com/rt2zz/redux-persist/issues/1169