### PR TITLE
Update Reactiflux discord channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ const persistConfig = {
 
 ### Chat Room
 
-[![#redux-persist on Discord](https://img.shields.io/discord/102860784329052160.svg)](https://discord.gg/ExrEvmv) #redux-persist channel in the [Reactiflux](https://www.reactiflux.com/) Discord
+[![#redux-persist on Discord](https://img.shields.io/discord/102860784329052160.svg)](https://discord.gg/ExrEvmv) #redux channel in the [Reactiflux](https://www.reactiflux.com/) Discord
 
 ### Blog articles from the community
 


### PR DESCRIPTION
Noticed that there is no longer a #redux-persist channel in the discord and that you should use #redux instead. Thanks