### PR TITLE
Enable `createMigrate` to handle async migrations #866

### DIFF
--- a/docs/migrations.md
+++ b/docs/migrations.md
@@ -13,7 +13,19 @@ const migrations = {
       device: undefined   
     }
   },
-  1: (state) => {
+  // You can use also `async () => {}` function
+  // For example to move users to other storage
+  1: async ({ users, ...state }) => {
+    try {
+      await insertToOtherStorage(users)
+
+      return state
+    } catch (e) {
+      // Don't forget about exceptions
+      return state
+    }
+  },
+  2: (state) => {
     // migration to keep only device state
     return {
       device: state.device

--- a/src/createMigrate.js
+++ b/src/createMigrate.js
@@ -42,15 +42,16 @@ export default function createMigrate(
     if (process.env.NODE_ENV !== 'production' && debug)
       console.log('redux-persist: migrationKeys', migrationKeys)
     try {
-      let migratedState = migrationKeys.reduce((state, versionKey) => {
+      return migrationKeys.reduce((promiseState, versionKey) => {
         if (process.env.NODE_ENV !== 'production' && debug)
           console.log(
             'redux-persist: running migration for versionKey',
             versionKey
           )
-        return migrations[versionKey](state)
-      }, state)
-      return Promise.resolve(migratedState)
+        return promiseState.then(state =>
+          Promise.resolve(migrations[versionKey](state))
+        )
+      }, Promise.resolve(state))
     } catch (err) {
       return Promise.reject(err)
     }


### PR DESCRIPTION
via: https://github.com/rt2zz/redux-persist/issues/806


```js
const migrations = {
  0: (state) => {
    // migration clear out device state
    return {
      ...state,
      device: undefined   
    }
  },
  // You can use also `async () => {}` function
  // For example to move users to other storage
  1: async ({ users, ...state }) => {
    try {
      await insertToOtherStorage(users)

      return state
    } catch (e) {
      // Don't forget about exceptions
      return state
    }
  },
  2: (state) => {
    // migration to keep only device state
    return {
      device: state.device
    }
  }
}
```