### PR TITLE
fix(types): Add manualPersist to PersistorOptions

### DIFF
--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -49,6 +49,7 @@ declare module "redux-persist/es/types" {
 
   interface PersistorOptions {
     enhancer?: StoreEnhancer<any>;
+    manualPersist?: boolean;
   }
 
   interface Storage {


### PR DESCRIPTION
This is a missing type in the `types.d.ts` file