### PR TITLE
Move sealed variable outside middleware

### DIFF
--- a/src/persistReducer.js
+++ b/src/persistReducer.js
@@ -53,6 +53,7 @@ export default function persistReducer<State: Object, Action: Object>(
   let _persistoid = null
   let _purge = false
   let _paused = true
+  let _sealed
   const conditionalUpdate = state => {
     // update the persistoid only if we are rehydrated and not paused
     state._persist.rehydrated &&
@@ -68,7 +69,7 @@ export default function persistReducer<State: Object, Action: Object>(
     let restState: State = rest
 
     if (action.type === PERSIST) {
-      let _sealed = false
+      _sealed = false
       let _rehydrate = (payload, err) => {
         // dev warning if we are already sealed
         if (process.env.NODE_ENV !== 'production' && _sealed)


### PR DESCRIPTION
This fix an issue when you use `replaceReducer` and `persist` right after in debug mode.
When you're in debug doing the above actions will call the rehydrate function in the timeout due to the call to `replaceReducer` and emit a timeout error.
Keeping variable outside sub middleware and initialising it at each `PERSIST` action fix the issue.