### PR TITLE
(fix): improved the type definition for persistCombineReducers

### DIFF
--- a/types/persistCombineReducers.d.ts
+++ b/types/persistCombineReducers.d.ts
@@ -10,6 +10,8 @@ declare module "redux-persist/es/persistCombineReducers" {
    * @returns reducer
    */
   // tslint:disable-next-line: strict-export-declare-modifiers
+  export default function persistCombineReducers<S>(config: PersistConfig<S>, reducers: ReducersMapObject<S, any>): Reducer<S & PersistPartial, any>;
+  // tslint:disable-next-line: strict-export-declare-modifiers
   export default function persistCombineReducers<S, A extends Action = Action>(config: PersistConfig<S>, reducers: ReducersMapObject<S, A>): Reducer<S & PersistPartial, A>;
 }
 


### PR DESCRIPTION
The definition is now (nearly) the same as the type definition for the combineREducers from redux. This allows the typechecking as is done in the [redux typescripting documentation](https://redux.js.org/recipes/usage-with-typescript#type-checking-reducers).

Prior to this change, the compiler would complain that the type `AnyAction` didn't match the reducer's action. And when adding the `AnyAction` to the `ChatActionTypes`, the compiler wouldn't know which actions were present.