### PR TITLE
fixed bug given config does not have a deserialize prop

### DIFF
--- a/src/createPersistoid.js
+++ b/src/createPersistoid.js
@@ -16,14 +16,8 @@ export default function createPersistoid(config: PersistConfig): Persistoid {
     config.keyPrefix !== undefined ? config.keyPrefix : KEY_PREFIX
   }${config.key}`
   const storage = config.storage
-  let serialize
-  if (config.serialize === false) {
-    serialize = x => x
-  } else if (typeof config.serialize === 'function') {
-    serialize = config.serialize
-  } else {
-    serialize = defaultSerialize
-  }
+  // config.serialize : boolean, serialize : function
+  const serialize = config.serialize ? defaultSerialize : (x) => x
   const writeFailHandler = config.writeFailHandler || null
 
   // initialize stateful values
@@ -35,7 +29,7 @@ export default function createPersistoid(config: PersistConfig): Persistoid {
 
   const update = (state: Object) => {
     // add any changed keys to the queue
-    Object.keys(state).forEach(key => {
+    Object.keys(state).forEach((key) => {
       if (!passWhitelistBlacklist(key)) return // is keyspace ignored? noop
       if (lastState[key] === state[key]) return // value unchanged? noop
       if (keysToProcess.indexOf(key) !== -1) return // is key already queued? noop
@@ -44,7 +38,7 @@ export default function createPersistoid(config: PersistConfig): Persistoid {
 
     //if any key is missing in the new state which was present in the lastState,
     //add it for processing too
-    Object.keys(lastState).forEach(key => {
+    Object.keys(lastState).forEach((key) => {
       if (
         state[key] === undefined &&
         passWhitelistBlacklist(key) &&
@@ -96,7 +90,7 @@ export default function createPersistoid(config: PersistConfig): Persistoid {
 
   function writeStagedState() {
     // cleanup any removed keys just before write.
-    Object.keys(stagedState).forEach(key => {
+    Object.keys(stagedState).forEach((key) => {
       if (lastState[key] === undefined) {
         delete stagedState[key]
       }

--- a/src/getStoredState.js
+++ b/src/getStoredState.js
@@ -13,21 +13,15 @@ export default function getStoredState(
   }${config.key}`
   const storage = config.storage
   const debug = config.debug
-  let deserialize
-  if (config.deserialize === false) {
-    deserialize = x => x
-  } else if (typeof config.deserialize === 'function') {
-    deserialize = config.deserialize
-  } else {
-    deserialize = defaultDeserialize
-  }
-  return storage.getItem(storageKey).then(serialized => {
+  // config.serialize <=> config.deserialize
+  const deserialize = config.serialize ? defaultDeserialize : (x) => x
+  return storage.getItem(storageKey).then((serialized) => {
     if (!serialized) return undefined
     else {
       try {
         let state = {}
         let rawState = deserialize(serialized)
-        Object.keys(rawState).forEach(key => {
+        Object.keys(rawState).forEach((key) => {
           state[key] = transforms.reduceRight((subState, transformer) => {
             return transformer.out(subState, key, rawState)
           }, deserialize(rawState[key]))


### PR DESCRIPTION
Thank you for this useful utility.  I've been using it for a couple of years now.

I have a storage package with its own serialization/deserialization capacity.  When I turned the `config.serialize: false`, the application failed.  This proposed updated fixes two things:

1. infers the `deserialized` value from the `config.serialize` setting (consistent with both the docs and type annotation)

2. it removes the code that presumes that config.serialize and `config.deserialize` can be a function; inconsistent with the type annotations.

\- E

