### PR TITLE
type safe persistStore

### DIFF
--- a/types/persistStore.d.ts
+++ b/types/persistStore.d.ts
@@ -1,6 +1,6 @@
-declare module "redux-persist/es/persistStore" {
-  import { Store } from 'redux';
-  import { PersistorOptions, Persistor } from "redux-persist/es/types";
+declare module 'redux-persist/es/persistStore' {
+  import { Store, Action, AnyAction } from 'redux';
+  import { PersistorOptions, Persistor } from 'redux-persist/es/types';
 
   /**
    * @desc Creates a persistor for a given store.
@@ -9,10 +9,14 @@ declare module "redux-persist/es/persistStore" {
    * @param callback bootstrap callback of sort.
    */
   // tslint:disable-next-line: strict-export-declare-modifiers
-  export default function persistStore(store: Store, persistorOptions?: PersistorOptions | null, callback?: () => any): Persistor;
+  export default function persistStore<S = any, A extends Action<any> = AnyAction>(
+    store: Store<S, A>,
+    persistorOptions?: PersistorOptions | null,
+    callback?: () => any,
+  ): Persistor;
 }
 
-declare module "redux-persist/lib/persistStore" {
-  export * from "redux-persist/es/persistStore";
-  export { default } from "redux-persist/es/persistStore";
+declare module 'redux-persist/lib/persistStore' {
+  export * from 'redux-persist/es/persistStore';
+  export { default } from 'redux-persist/es/persistStore';
 }

--- a/types/persistStore.d.ts
+++ b/types/persistStore.d.ts
@@ -1,6 +1,6 @@
-declare module 'redux-persist/es/persistStore' {
-  import { Store, Action, AnyAction } from 'redux';
-  import { PersistorOptions, Persistor } from 'redux-persist/es/types';
+declare module "redux-persist/es/persistStore" {
+  import { Store, Action, AnyAction } from "redux";
+  import { PersistorOptions, Persistor } from "redux-persist/es/types";
 
   /**
    * @desc Creates a persistor for a given store.
@@ -16,7 +16,7 @@ declare module 'redux-persist/es/persistStore' {
   ): Persistor;
 }
 
-declare module 'redux-persist/lib/persistStore' {
-  export * from 'redux-persist/es/persistStore';
-  export { default } from 'redux-persist/es/persistStore';
+declare module "redux-persist/lib/persistStore" {
+  export * from "redux-persist/es/persistStore";
+  export { default } from "redux-persist/es/persistStore";
 }


### PR DESCRIPTION
https://github.com/rt2zz/redux-persist/issues/1140

`redux` compatible with `persistStore`.

```ts
// persistStore.d.ts

declare module 'redux-persist/es/persistStore' {
  import { Store, Action, AnyAction } from 'redux';
  import { PersistorOptions, Persistor } from 'redux-persist/es/types';

  /**
   * @desc Creates a persistor for a given store.
   * @param store store to be persisted (or match an existent storage)
   * @param persistorOptions enhancers of the persistor
   * @param callback bootstrap callback of sort.
   */
  // tslint:disable-next-line: strict-export-declare-modifiers
  export default function persistStore<S = any, A extends Action<any> = AnyAction>(
    store: Store<S, A>,
    persistorOptions?: PersistorOptions | null,
    callback?: () => any,
  ): Persistor;
}

declare module 'redux-persist/lib/persistStore' {
  export * from 'redux-persist/es/persistStore';
  export { default } from 'redux-persist/es/persistStore';
}
```