### PR TITLE
improved type for white/black lists of persistConfig

### DIFF
--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -31,8 +31,8 @@ declare module "redux-persist/es/types" {
      * @deprecated keyPrefix is going to be removed in v6.
      */
     keyPrefix?: string;
-    blacklist?: Array<string>;
-    whitelist?: Array<string>;
+    blacklist?: Array<keyof S>;
+    whitelist?: Array<keyof S>;
     transforms?: Array<Transform<HSS, ESS, S, RS>>;
     throttle?: number;
     migrate?: PersistMigrate;


### PR DESCRIPTION
Forces each value in whitelist and blacklist to be a valid key of root state