### PR TITLE
Moving away from the words ‘blacklist’ and ‘whitelist’

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ const App = () => {
   - arguments
     - [**config**](https://github.com/rt2zz/redux-persist/blob/master/src/types.js#L13-L27) *object*
       - required config: `key, storage`
-      - notable other config: `whitelist, blacklist, version, stateReconciler, debug`
+      - notable other config: `allowlist, blocklist, version, stateReconciler, debug`
     - **reducer** *function*
       - any reducer will work, typically this would be the top level reducer returned by `combineReducers`
   - returns an enhanced reducer
@@ -136,26 +136,26 @@ Redux persist ships with react integration as a convenience. The `PersistGate` c
 1. `loading` prop: The provided loading value will be rendered until persistence is complete at which point children will be rendered.
 2. function children: The function will be invoked with a single `bootstrapped` argument. When bootstrapped is true, persistence is complete and it is safe to render the full app. This can be useful for adding transition animations.
 
-## Blacklist & Whitelist
+## Blocklist & Allowlist
 By Example:
 ```js
-// BLACKLIST
+// BLOCKLIST
 const persistConfig = {
   key: 'root',
   storage: storage,
-  blacklist: ['navigation'] // navigation will not be persisted
+  blocklist: ['navigation'] // navigation will not be persisted
 };
 
-// WHITELIST
+// ALLOWLIST
 const persistConfig = {
   key: 'root',
   storage: storage,
-  whitelist: ['navigation'] // only navigation will be persisted
+  allowlist: ['navigation'] // only navigation will be persisted
 };
 ```
 
 ## Nested Persists
-Nested persist can be useful for including different storage adapters, code splitting, or deep filtering. For example while blacklist and whitelist only work one level deep, but we can use a nested persist to blacklist a deeper value:
+Nested persist can be useful for including different storage adapters, code splitting, or deep filtering. For example while blocklist and allowlist only work one level deep, but we can use a nested persist to blocklist a deeper value:
 ```js
 import { combineReducers } from 'redux'
 import { persistReducer } from 'redux-persist'
@@ -166,13 +166,13 @@ import { authReducer, otherReducer } from './reducers'
 const rootPersistConfig = {
   key: 'root',
   storage: storage,
-  blacklist: ['auth']
+  blocklist: ['auth']
 }
 
 const authPersistConfig = {
   key: 'auth',
   storage: storage,
-  blacklist: ['somethingTemporary']
+  blocklist: ['somethingTemporary']
 }
 
 const rootReducer = combineReducers({
@@ -220,7 +220,7 @@ const SetTransform = createTransform(
     return { ...outboundState, mySet: new Set(outboundState.mySet) };
   },
   // define which reducers this transform gets called for.
-  { whitelist: ['someReducer'] }
+  { allowlist: ['someReducer'] }
 );
 
 export default SetTransform;

--- a/docs/api.md
+++ b/docs/api.md
@@ -54,8 +54,8 @@ The Persistor is a redux store unto itself, plus
   key: string, // the key for the persist
   storage: Object, // the storage adapter, following the AsyncStorage api
   version?: number, // the state version as an integer (defaults to -1)
-  blacklist?: Array<string>, // do not persist these keys
-  whitelist?: Array<string>, // only persist these keys
+  blocklist?: Array<string>, // do not persist these keys
+  allowlist?: Array<string>, // only persist these keys
   migrate?: (Object, number) => Promise<Object>,
   transforms?: Array<Transform>,
   throttle?: number, // ms to throttle state writes

--- a/src/createPersistoid.js
+++ b/src/createPersistoid.js
@@ -7,9 +7,21 @@ import type { Persistoid, PersistConfig, Transform } from './types'
 type IntervalID = any // @TODO remove once flow < 0.63 support is no longer required.
 
 export default function createPersistoid(config: PersistConfig): Persistoid {
+  if (process.env.NODE_ENV !== 'production') {
+    if (config.whitelist) {
+      console.warn(
+        `redux-persist "whitelist" is deprecated and will be removed in the next major update. Use "allowlist" instead.`
+      )
+    }
+    if (config.blacklist) {
+      console.warn(
+        `redux-persist "blacklist" is deprecated and will be removed in the next major update. Use "blocklist" instead.`
+      )
+    }
+  }
   // defaults
-  const blacklist: ?Array<string> = config.blacklist || null
-  const whitelist: ?Array<string> = config.whitelist || null
+  const blocklist: ?Array<string> = config.blocklist || config.blacklist || null
+  const allowlist: ?Array<string> = config.allowlist || config.whitelist || null
   const transforms = config.transforms || []
   const throttle = config.throttle || 0
   const storageKey = `${
@@ -36,7 +48,7 @@ export default function createPersistoid(config: PersistConfig): Persistoid {
   const update = (state: Object) => {
     // add any changed keys to the queue
     Object.keys(state).forEach(key => {
-      if (!passWhitelistBlacklist(key)) return // is keyspace ignored? noop
+      if (!passAllowlistBlocklist(key)) return // is keyspace ignored? noop
       if (lastState[key] === state[key]) return // value unchanged? noop
       if (keysToProcess.indexOf(key) !== -1) return // is key already queued? noop
       keysToProcess.push(key) // add key to queue
@@ -47,7 +59,7 @@ export default function createPersistoid(config: PersistConfig): Persistoid {
     Object.keys(lastState).forEach(key => {
       if (
         state[key] === undefined &&
-        passWhitelistBlacklist(key) &&
+        passAllowlistBlocklist(key) &&
         keysToProcess.indexOf(key) === -1 &&
         lastState[key] !== undefined
       ) {
@@ -107,10 +119,10 @@ export default function createPersistoid(config: PersistConfig): Persistoid {
       .catch(onWriteFail)
   }
 
-  function passWhitelistBlacklist(key) {
-    if (whitelist && whitelist.indexOf(key) === -1 && key !== '_persist')
+  function passAllowlistBlocklist(key) {
+    if (allowlist && allowlist.indexOf(key) === -1 && key !== '_persist')
       return false
-    if (blacklist && blacklist.indexOf(key) !== -1) return false
+    if (blocklist && blocklist.indexOf(key) !== -1) return false
     return true
   }
 

--- a/src/createTransform.js
+++ b/src/createTransform.js
@@ -1,8 +1,10 @@
 // @flow
 
 type TransformConfig = {
-  whitelist?: Array<string>,
-  blacklist?: Array<string>,
+  whitelist?: Array<string>, // Deprecated
+  blacklist?: Array<string>, // Deprecated
+  allowlist?: Array<string>,
+  blocklist?: Array<string>,
 }
 
 export default function createTransform(
@@ -12,22 +14,34 @@ export default function createTransform(
   outbound: ?Function,
   config: TransformConfig = {}
 ) {
-  let whitelist = config.whitelist || null
-  let blacklist = config.blacklist || null
+  if (process.env.NODE_ENV !== 'production') {
+    if (config.whitelist) {
+      console.warn(
+        `redux-persist "whitelist" is deprecated and will be removed in the next major update. Use "allowlist" instead.`
+      )
+    }
+    if (config.blacklist) {
+      console.warn(
+        `redux-persist "blacklist" is deprecated and will be removed in the next major update. Use "blocklist" instead.`
+      )
+    }
+  }
+  let allowlist = config.allowlist || config.whitelist || null
+  let blocklist = config.blocklist || config.blacklist || null
 
-  function whitelistBlacklistCheck(key) {
-    if (whitelist && whitelist.indexOf(key) === -1) return true
-    if (blacklist && blacklist.indexOf(key) !== -1) return true
+  function allowlistBlocklistCheck(key) {
+    if (allowlist && allowlist.indexOf(key) === -1) return true
+    if (blocklist && blocklist.indexOf(key) !== -1) return true
     return false
   }
 
   return {
     in: (state: Object, key: string, fullState: Object) =>
-      !whitelistBlacklistCheck(key) && inbound
+      !allowlistBlocklistCheck(key) && inbound
         ? inbound(state, key, fullState)
         : state,
     out: (state: Object, key: string, fullState: Object) =>
-      !whitelistBlacklistCheck(key) && outbound
+      !allowlistBlocklistCheck(key) && outbound
         ? outbound(state, key, fullState)
         : state,
   }

--- a/src/integration/getStoredStateMigrateV4.js
+++ b/src/integration/getStoredStateMigrateV4.js
@@ -9,8 +9,10 @@ type V4Config = {
   serialize: boolean,
   keyPrefix?: string,
   transforms?: Array<Transform>,
-  blacklist?: Array<string>,
-  whitelist?: Array<string>,
+  blacklist?: Array<string>, // Deprecated
+  whitelist?: Array<string>, // Deprecated
+  blocklist?: Array<string>,
+  allowlist?: Array<string>,
 }
 
 export default function getStoredState(v4Config: V4Config) {
@@ -103,8 +105,8 @@ function getStoredStateV4(v4Config: V4Config) {
       v4Config.serialize === false
         ? data => data
         : (serial: string) => JSON.parse(serial)
-    const blacklist = v4Config.blacklist || []
-    const whitelist = v4Config.whitelist || false
+    const blocklist = v4Config.blocklist || v4Config.blacklist || []
+    const allowlist = v4Config.allowlist || v4Config.whitelist || false
     const transforms = v4Config.transforms || []
     const keyPrefix =
       v4Config.keyPrefix !== undefined ? v4Config.keyPrefix : KEY_PREFIX
@@ -128,7 +130,7 @@ function getStoredStateV4(v4Config: V4Config) {
       let persistKeys = allKeys
         .filter(key => key.indexOf(keyPrefix) === 0)
         .map(key => key.slice(keyPrefix.length))
-      let keysToRestore = persistKeys.filter(passWhitelistBlacklist)
+      let keysToRestore = persistKeys.filter(passAllowlistBlocklist)
 
       let restoreCount = keysToRestore.length
       if (restoreCount === 0) resolve(undefined)
@@ -167,9 +169,9 @@ function getStoredStateV4(v4Config: V4Config) {
       return state
     }
 
-    function passWhitelistBlacklist(key) {
-      if (whitelist && whitelist.indexOf(key) === -1) return false
-      if (blacklist.indexOf(key) !== -1) return false
+    function passAllowlistBlocklist(key) {
+      if (allowlist && allowlist.indexOf(key) === -1) return false
+      if (blocklist.indexOf(key) !== -1) return false
       return true
     }
 

--- a/src/persistStore.js
+++ b/src/persistStore.js
@@ -46,8 +46,10 @@ export default function persistStore(
   if (process.env.NODE_ENV !== 'production') {
     let optionsToTest: Object = options || {}
     let bannedKeys = [
-      'blacklist',
-      'whitelist',
+      'blacklist', // Deprecated
+      'whitelist', // Deprecated
+      'blocklist',
+      'allowlist',
       'transforms',
       'storage',
       'keyPrefix',
@@ -122,7 +124,7 @@ export default function persistStore(
     },
   }
 
-  if (!(options && options.manualPersist)){
+  if (!(options && options.manualPersist)) {
     persistor.persist()
   }
 

--- a/src/types.js
+++ b/src/types.js
@@ -15,8 +15,10 @@ export type PersistConfig = {
   storage: Object,
   key: string,
   keyPrefix?: string, // @TODO remove in v6
-  blacklist?: Array<string>,
-  whitelist?: Array<string>,
+  blacklist?: Array<string>, // Deprecated
+  whitelist?: Array<string>, // Deprecated
+  blocklist?: Array<string>,
+  allowlist?: Array<string>,
   transforms?: Array<Transform>,
   throttle?: number,
   migrate?: (PersistedState, number) => Promise<PersistedState>,
@@ -31,7 +33,7 @@ export type PersistConfig = {
 
 export type PersistorOptions = {
   enhancer?: Function,
-  manualPersist?: boolean
+  manualPersist?: boolean,
 }
 
 export type Storage = {

--- a/types/createTransform.d.ts
+++ b/types/createTransform.d.ts
@@ -2,8 +2,16 @@ declare module "redux-persist/es/createTransform" {
   import { PersistConfig, Transform, TransformInbound, TransformOutbound } from "redux-persist/es/types";
 
   interface TransformConfig {
+    /**
+     * @deprecated This property will be removed in the next major update. Use "allowlist" instead.
+     */
     whitelist?: Array<string>;
+    /**
+     * @deprecated This property will be removed in the next major update. Use "blocklist" instead. 
+     */
     blacklist?: Array<string>;
+    allowlist?: Array<string>;
+    blocklist?: Array<string>;
   }
 
   // tslint:disable-next-line: strict-export-declare-modifiers

--- a/types/integration/getStoredStateMigrateV4.d.ts
+++ b/types/integration/getStoredStateMigrateV4.d.ts
@@ -11,8 +11,16 @@ declare module "redux-persist/es/integration/getStoredStateMigrateV4" {
     storage?: V4Storage;
     keyPrefix?: string;
     transforms?: Array<Transform<any, any>>;
+    /**
+     * @deprecated Use "blocklist" instead. This property will be removed in the next major update.
+     */
     blacklist?: Array<string>;
+    /**
+     * @deprecated Use "allowlist" instead. This property will be removed in the next major update.
+     */
     whitelist?: Array<string>;
+    allowlist?: Array<string>;
+    blocklist?: Array<string>;
   }
 
   // tslint:disable-next-line: strict-export-declare-modifiers

--- a/types/types.d.ts
+++ b/types/types.d.ts
@@ -31,8 +31,16 @@ declare module "redux-persist/es/types" {
      * @deprecated keyPrefix is going to be removed in v6.
      */
     keyPrefix?: string;
+    /**
+     * @deprecated This property will be removed in the next major update. Use "blocklist" instead.
+     */
     blacklist?: Array<string>;
+    /**
+     * @deprecated This property will be removed in the next major update. Use "allowlist" instead. 
+     */
     whitelist?: Array<string>;
+    blocklist?: Array<string>;
+    allowlist?: Array<string>;
     transforms?: Array<Transform<HSS, ESS, S, RS>>;
     throttle?: number;
     migrate?: PersistMigrate;


### PR DESCRIPTION
This topic is :fire:HOT:fire: lately and many large companies like Google moving away from these words to be more inclusive.

This PR marks the 'blacklist' and 'whitelist' properties as deprecated until the next major update. That shouldn't broke anything and should satisfy both sides.

![Screenshot from 2021-04-01 15-02-34](https://user-images.githubusercontent.com/14310216/113305897-c8530100-9303-11eb-8b71-897d28607b0b.png)
![Screenshot from 2021-04-01 15-24-08](https://user-images.githubusercontent.com/14310216/113305902-c9842e00-9303-11eb-8701-69b15a4036bd.png)
![Screenshot from 2021-04-01 15-24-31](https://user-images.githubusercontent.com/14310216/113305903-c9842e00-9303-11eb-8a14-d3690ead227e.png)
