### PR TITLE
README: Fix nested persists section

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ import { authReducer, otherReducer } from './reducers'
 const rootPersistConfig = {
   key: 'root',
   storage: storage,
-  blacklist: ['auth']
+  whitelist: ['auth']
 }
 
 const authPersistConfig = {


### PR DESCRIPTION
If the root skips all of `auth`, then there's no purpose to also skipping `auth.xyz` in a nested config.