### PR TITLE
try catch for writeStagedState serialize

### DIFF
--- a/src/createPersistoid.js
+++ b/src/createPersistoid.js
@@ -101,9 +101,17 @@ export default function createPersistoid(config: PersistConfig): Persistoid {
         delete stagedState[key]
       }
     })
-
+    let serializedState 
+    try {
+      serializedState = serialize(stagedState)
+    } catch (err) {
+        console.error(
+          'redux-persist/createPersistoid: error serializing state',
+          err
+        )
+    }
     writePromise = storage
-      .setItem(storageKey, serialize(stagedState))
+      .setItem(storageKey, serializedState)
       .catch(onWriteFail)
   }
 


### PR DESCRIPTION
Even though there was ".catch" on this line, it only caught errors from setItem, so an error from serialize would be completely unhandled.
