### PR TITLE
If throttle is 0, do not use interval.

### DIFF
--- a/src/createPersistoid.js
+++ b/src/createPersistoid.js
@@ -55,12 +55,18 @@ export default function createPersistoid(config: PersistConfig): Persistoid {
       }
     })
 
-    // start the time iterator if not running (read: throttle)
-    if (timeIterator === null) {
-      timeIterator = setInterval(processNextKey, throttle)
-    }
-
     lastState = state
+    // if no throttle, there's no point in using
+    // an interval, this allows background execution in RN.
+    if (!throttle) {
+      while (keysToProcess.length) {
+        processNextKey()
+      }
+    } else {
+      if (timeIterator === null) {
+        timeIterator = setInterval(processNextKey, throttle)
+      }
+    }
   }
 
   function processNextKey() {


### PR DESCRIPTION
Fixes persistence in background.

This allows for persistence to fire in RN while in background if throttle is not 0, by removing intervals.