### PR TITLE
fix: add missing optional peer dependency react

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,6 @@
     "react": {
       "optional": true
     }
-  }
+  },
   "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -85,7 +85,13 @@
     "storage-memory": "0.0.2"
   },
   "peerDependencies": {
-    "redux": ">4.0.0"
+    "redux": ">4.0.0",
+    "react": ">=16"
   },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    }
+  }
   "dependencies": {}
 }


### PR DESCRIPTION
`redux-persist` tries to import `react` without declaring it as a peer dependency so this PR adds it as an optional peer dependency
https://github.com/rt2zz/redux-persist/blob/d7efde9115a0bd2d6a0309ac6fb1c018bf06dc30/src/integration/react.js#L2