### PR TITLE
refactor: update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Persist and rehydrate a redux store.
 **Web**: no breaking changes
 **React Native**: Users must now explicitly pass their storage engine in. e.g.
 ```js
-import AsyncStorage from '@react-native-community/async-storage';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 
 const persistConfig = {
   //...


### PR DESCRIPTION
React native community  async storage has been deprecated.. moving on to Async Storage has moved to new organization: https://github.com/react-native-async-storage/async-storage