### PR TITLE
sap-term-changes: Rename black/white according to SAP

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ const App = () => {
   - arguments
     - [**config**](https://github.com/rt2zz/redux-persist/blob/master/src/types.js#L13-L27) *object*
       - required config: `key, storage`
-      - notable other config: `whitelist, blacklist, version, stateReconciler, debug`
+      - notable other config: `allowlist, denylist, version, stateReconciler, debug`
     - **reducer** *function*
       - any reducer will work, typically this would be the top level reducer returned by `combineReducers`
   - returns an enhanced reducer
@@ -181,26 +181,26 @@ Redux persist ships with react integration as a convenience. The `PersistGate` c
 1. `loading` prop: The provided loading value will be rendered until persistence is complete at which point children will be rendered.
 2. function children: The function will be invoked with a single `bootstrapped` argument. When bootstrapped is true, persistence is complete and it is safe to render the full app. This can be useful for adding transition animations.
 
-## Blacklist & Whitelist
+## Denylist & Allowlist
 By Example:
 ```js
-// BLACKLIST
+// DENYLIST
 const persistConfig = {
   key: 'root',
   storage: storage,
-  blacklist: ['navigation'] // navigation will not be persisted
+  denylist: ['navigation'] // navigation will not be persisted
 };
 
-// WHITELIST
+// ALLOWLIST
 const persistConfig = {
   key: 'root',
   storage: storage,
-  whitelist: ['navigation'] // only navigation will be persisted
+  allowlist: ['navigation'] // only navigation will be persisted
 };
 ```
 
 ## Nested Persists
-Nested persist can be useful for including different storage adapters, code splitting, or deep filtering. For example while blacklist and whitelist only work one level deep, but we can use a nested persist to blacklist a deeper value:
+Nested persist can be useful for including different storage adapters, code splitting, or deep filtering. For example while denylist and allowlist only work one level deep, but we can use a nested persist to denylist a deeper value:
 ```js
 import { combineReducers } from 'redux'
 import { persistReducer } from 'redux-persist'
@@ -211,13 +211,13 @@ import { authReducer, otherReducer } from './reducers'
 const rootPersistConfig = {
   key: 'root',
   storage: storage,
-  blacklist: ['auth']
+  denylist: ['auth']
 }
 
 const authPersistConfig = {
   key: 'auth',
   storage: storage,
-  blacklist: ['somethingTemporary']
+  denylist: ['somethingTemporary']
 }
 
 const rootReducer = combineReducers({
@@ -265,7 +265,7 @@ const SetTransform = createTransform(
     return { ...outboundState, mySet: new Set(outboundState.mySet) };
   },
   // define which reducers this transform gets called for.
-  { whitelist: ['someReducer'] }
+  { allowlist: ['someReducer'] }
 );
 
 export default SetTransform;

--- a/docs/api.md
+++ b/docs/api.md
@@ -54,8 +54,8 @@ The Persistor is a redux store unto itself, plus
   key: string, // the key for the persist
   storage: Object, // the storage adapter, following the AsyncStorage api
   version?: number, // the state version as an integer (defaults to -1)
-  blacklist?: Array<string>, // do not persist these keys
-  whitelist?: Array<string>, // only persist these keys
+  denylist?: Array<string>, // do not persist these keys
+  allowlist?: Array<string>, // only persist these keys
   migrate?: (Object, number) => Promise<Object>,
   transforms?: Array<Transform>,
   throttle?: number, // ms to throttle state writes

--- a/src/createPersistoid.ts
+++ b/src/createPersistoid.ts
@@ -6,8 +6,8 @@ import { KeyAccessState } from './types'
 
 export default function createPersistoid(config: PersistConfig<any>): Persistoid {
   // defaults
-  const blacklist: string[] | null = config.blacklist || null
-  const whitelist: string[] | null = config.whitelist || null
+  const denylist: string[] | null = config.denylist || null
+  const allowlist: string[] | null = config.allowlist || null
   const transforms = config.transforms || []
   const throttle = config.throttle || 0
   const storageKey = `${
@@ -34,7 +34,7 @@ export default function createPersistoid(config: PersistConfig<any>): Persistoid
   const update = (state: KeyAccessState) => {
     // add any changed keys to the queue
     Object.keys(state).forEach(key => {
-      if (!passWhitelistBlacklist(key)) return // is keyspace ignored? noop
+      if (!passAllowlistDenylist(key)) return // is keyspace ignored? noop
       if (lastState[key] === state[key]) return // value unchanged? noop
       if (keysToProcess.indexOf(key) !== -1) return // is key already queued? noop
       keysToProcess.push(key) // add key to queue
@@ -45,7 +45,7 @@ export default function createPersistoid(config: PersistConfig<any>): Persistoid
     Object.keys(lastState).forEach(key => {
       if (
         state[key] === undefined &&
-        passWhitelistBlacklist(key) &&
+        passAllowlistDenylist(key) &&
         keysToProcess.indexOf(key) === -1 &&
         lastState[key] !== undefined
       ) {
@@ -108,10 +108,10 @@ export default function createPersistoid(config: PersistConfig<any>): Persistoid
       .catch(onWriteFail)
   }
 
-  function passWhitelistBlacklist(key: string) {
-    if (whitelist && whitelist.indexOf(key) === -1 && key !== '_persist')
+  function passAllowlistDenylist(key: string) {
+    if (allowlist && allowlist.indexOf(key) === -1 && key !== '_persist')
       return false
-    if (blacklist && blacklist.indexOf(key) !== -1) return false
+    if (denylist && denylist.indexOf(key) !== -1) return false
     return true
   }
 

--- a/src/createTransform.ts
+++ b/src/createTransform.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 type TransformConfig = {
-  whitelist?: Array<string>,
-  blacklist?: Array<string>,
+  allowlist?: Array<string>,
+  denylist?: Array<string>,
 }
 
 export default function createTransform(
@@ -13,22 +13,22 @@ export default function createTransform(
   outbound: Function,
   config: TransformConfig = {}
 ): any {
-  const whitelist = config.whitelist || null
-  const blacklist = config.blacklist || null
+  const allowlist = config.allowlist || null
+  const denylist = config.denylist || null
 
-  function whitelistBlacklistCheck(key: string) {
-    if (whitelist && whitelist.indexOf(key) === -1) return true
-    if (blacklist && blacklist.indexOf(key) !== -1) return true
+  function allowlistDenylistCheck(key: string) {
+    if (allowlist && allowlist.indexOf(key) === -1) return true
+    if (denylist && denylist.indexOf(key) !== -1) return true
     return false
   }
 
   return {
     in: (state: Record<string, unknown>, key: string, fullState: Record<string, unknown>) =>
-      !whitelistBlacklistCheck(key) && inbound
+      !allowlistDenylistCheck(key) && inbound
         ? inbound(state, key, fullState)
         : state,
     out: (state: Record<string, unknown>, key: string, fullState: Record<string, unknown>) =>
-      !whitelistBlacklistCheck(key) && outbound
+      !allowlistDenylistCheck(key) && outbound
         ? outbound(state, key, fullState)
         : state,
   }

--- a/src/integration/getStoredStateMigrateV4.ts
+++ b/src/integration/getStoredStateMigrateV4.ts
@@ -8,8 +8,8 @@ type V4Config = {
   serialize: boolean,
   keyPrefix?: string,
   transforms?: Array<Transform<any, any>>,
-  blacklist?: Array<string>,
-  whitelist?: Array<string>,
+  denylist?: Array<string>,
+  allowlist?: Array<string>,
 }
 
 export default function getStoredState(v4Config: V4Config) {
@@ -105,8 +105,8 @@ function getStoredStateV4(v4Config: V4Config) {
       v4Config.serialize === false
         ? (data: any) => data
         : (serial: string) => JSON.parse(serial)
-    const blacklist = v4Config.blacklist || []
-    const whitelist = v4Config.whitelist || false
+    const denylist = v4Config.denylist || []
+    const allowlist = v4Config.allowlist || false
     const transforms = v4Config.transforms || []
     const keyPrefix =
       v4Config.keyPrefix !== undefined ? v4Config.keyPrefix : KEY_PREFIX
@@ -130,7 +130,7 @@ function getStoredStateV4(v4Config: V4Config) {
       const persistKeys = allKeys
         .filter(key => key.indexOf(keyPrefix) === 0)
         .map(key => key.slice(keyPrefix.length))
-      const keysToRestore = persistKeys.filter(passWhitelistBlacklist)
+      const keysToRestore = persistKeys.filter(passAllowlistDenylist)
 
       const restoreCount = keysToRestore.length
       if (restoreCount === 0) resolve(undefined)
@@ -169,9 +169,9 @@ function getStoredStateV4(v4Config: V4Config) {
       return state
     }
 
-    function passWhitelistBlacklist(key: string) {
-      if (whitelist && whitelist.indexOf(key) === -1) return false
-      if (blacklist.indexOf(key) !== -1) return false
+    function passAllowlistDenylist(key: string) {
+      if (allowlist && allowlist.indexOf(key) === -1) return false
+      if (denylist.indexOf(key) !== -1) return false
       return true
     }
 

--- a/src/persistStore.ts
+++ b/src/persistStore.ts
@@ -42,8 +42,8 @@ export default function persistStore(
   if (process.env.NODE_ENV !== 'production') {
     const optionsToTest: OptionToTestObject = options || {}
     const bannedKeys = [
-      'blacklist',
-      'whitelist',
+      'denylist',
+      'allowlist',
       'transforms',
       'storage',
       'keyPrefix',

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,8 +38,8 @@ export interface PersistConfig<S, RS = any, HSS = any, ESS = any> {
    * @deprecated keyPrefix is going to be removed in v6.
    */
   keyPrefix?: string;
-  blacklist?: Array<string>;
-  whitelist?: Array<string>;
+  denylist?: Array<string>;
+  allowlist?: Array<string>;
   transforms?: Array<Transform<HSS, ESS, S, RS>>;
   throttle?: number;
   migrate?: PersistMigrate;


### PR DESCRIPTION
SAP is dropping the use of master/slave and blacklist/[whitelist](https://www.techtarget.com/whatis/definition/whitelist). It wants its language to be as inclusive as possible and is replacing the well-known terms with alternatives, depending on usage.
Shall we rename blacklist/whitelist terminologies as well?

This would be a breaking change and would require a doc to list down the migration step. I'm happy to edit that page but couldn't find it. It could be written on change log file as well.

more read [here](https://www.techtarget.com/searchsap/news/252488768/SAP-sets-alternatives-to-master-slave-blacklist-whitelist#:~:text=The%20blacklist%2Fwhitelist%20alternatives%20have,its%20push%20for%20term%20changes.)