### PR TITLE
Update Readme confing broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ const App = () => {
 
 #### `persistReducer(config, reducer)`
   - arguments
-    - [**config**](https://github.com/rt2zz/redux-persist/blob/master/src/types.js#L13-L27) *object*
+    - [**config**](https://github.com/rt2zz/redux-persist/blob/master/src/types.ts#L33-L56) *object*
       - required config: `key, storage`
       - notable other config: `whitelist, blacklist, version, stateReconciler, debug`
     - **reducer** *function*


### PR DESCRIPTION
Minor README link fix. Previously it was in a JS file now it's in a TS file.