### PR TITLE
Sets PersistGate bootstrapped state in component constructor.

### DIFF
--- a/src/integration/react.ts
+++ b/src/integration/react.ts
@@ -19,8 +19,13 @@ export class PersistGate extends PureComponent<Props, State> {
     loading: null,
   }
 
-  state = {
-    bootstrapped: false,
+  constructor(props: Props) {
+    super(props);
+    const { persistor } = props;
+    const { bootstrapped } = persistor.getState();
+    this.state = {
+      bootstrapped,
+    };
   }
   _unsubscribe?: () => void
 


### PR DESCRIPTION
Fixes SSR compatibility.

ref: https://github.com/gatsbyjs/gatsby/issues/37701