### PR TITLE
Replace recommended storage engine for secure storage on react-native

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ const persistConfig = {
   **[redux-persist-indexeddb-storage](https://github.com/machester4/redux-persist-indexeddb-storage)** recommended for web via [localForage](https://github.com/localForage/localForage)
 - **[redux-persist-node-storage](https://github.com/pellejacobs/redux-persist-node-storage)** for use in nodejs environments.
 - **[redux-persist-pouchdb](https://github.com/yanick/redux-persist-pouchdb)** Storage engine for PouchDB.
-- **[redux-persist-sensitive-storage](https://github.com/CodingZeal/redux-persist-sensitive-storage)** react-native, for sensitive information (uses [react-native-sensitive-info](https://github.com/mCodex/react-native-sensitive-info)).
+- **[react-native-encrypted-storage](https://github.com/emeraldsanto/react-native-encrypted-storage)** react-native, for sensitive information (uses EncryptedSharedPreferences and KeyChain for data storage).
 - **[redux-persist-weapp-storage](https://github.com/cuijiemmx/redux-casa/tree/master/packages/redux-persist-weapp-storage)** Storage engine for wechat mini program, also compatible with wepy
 - **[redux-persist-webextension-storage](https://github.com/ssorallen/redux-persist-webextension-storage)** Storage engine for browser (Chrome, Firefox) web extension storage
 - **[@bankify/redux-persist-realm](https://github.com/bankifyio/redux-persist-realm)** Storage engine for Realm database, you will need to install Realm first


### PR DESCRIPTION
The previously recommended `redux-persist-sensitive-storage` only encrypts the data on iOS; on Android it is stored in clear text and readable via the file browser. There exists an alpha-Branch which solves the problem, but this is in alpha years now and not updated anymore. Also, this branch fails on Android 9 and older.

We switched to [react-native-encrypted-storage](https://www.npmjs.com/package/react-native-encrypted-storage) in all our projects; it solves the problems mentioned above and works fine. 

This would be a better suggestion than the currently suggested storage library, which has a high risk for security breaches for Android users.